### PR TITLE
Implement support for using global blosc functions

### DIFF
--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -2,8 +2,19 @@
 from __future__ import absolute_import, print_function, division
 
 
+import atexit
+
+
 from zarr.core import empty, zeros, ones, full, array, open
-from zarr.ext import blosc_version
+from zarr.ext import blosc_version, init as _init, destroy as _destroy, \
+    set_blosc_options
 from zarr import defaults
 from zarr import constants
 from zarr.version import version as __version__
+
+
+import multiprocessing
+_cpu_count = multiprocessing.cpu_count()
+_init()
+set_blosc_options(use_context=False, nthreads=_cpu_count)
+atexit.register(_destroy)

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -14,7 +14,7 @@ from zarr.version import version as __version__
 
 
 import multiprocessing
-_cpu_count = multiprocessing.cpu_count()
+ncores = multiprocessing.cpu_count()
 _init()
-set_blosc_options(use_context=False, nthreads=_cpu_count)
+set_blosc_options(use_context=False, nthreads=ncores)
 atexit.register(_destroy)

--- a/zarr/ext.pyx
+++ b/zarr/ext.pyx
@@ -74,7 +74,7 @@ cdef extern from "blosc.h":
 
 
 def blosc_version():
-    """Return the version of c-blosc that zarr was compiled with."""
+    """Return the version of blosc that zarr was compiled with."""
 
     # all the 'decode' contorsions are for Python 3 returning actual strings
     ver_str = <char *> BLOSC_VERSION_STRING
@@ -97,7 +97,24 @@ def destroy():
 _blosc_use_context = False
 
 
-def set_blosc_options(use_context, nthreads=None):
+def set_blosc_options(use_context=False, nthreads=None):
+    """Set options for how the blosc compressor is used.
+
+    Parameters
+    ----------
+    use_context : bool, optional
+        If False, blosc will be used in non-contextual mode, which is best
+        when using zarr in a single-threaded environment because it allows
+        blosc to use multiple threads internally. If True, blosc will be used
+        in contextual mode, which is better when using zarr in a
+        multi-threaded environment like dask.array because it avoids the blosc
+        global lock and so multiple blosc operations can be running
+        concurrently.
+    nthreads : int, optional
+        Number of internal threads to use when running blosc in non-contextual
+        mode.
+
+    """
     global _blosc_use_context
     _blosc_use_context = use_context
     if not use_context:

--- a/zarr/tests/test_array.py
+++ b/zarr/tests/test_array.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_array_equal
 from zarr.ext import Array, SynchronizedArray, PersistentArray, \
     SynchronizedPersistentArray, LazyArray, SynchronizedLazyArray, \
     LazyPersistentArray, SynchronizedLazyPersistentArray
-from zarr import defaults
+from zarr import defaults, set_blosc_options
 
 
 class ArrayTests(object):
@@ -479,3 +479,14 @@ class TestSynchronizedLazyPersistentArray(TestPersistentArray):
             lambda: shutil.rmtree(path) if os.path.exists(path) else None
         )
         return SynchronizedLazyPersistentArray(**kwargs)
+
+
+class TestArrayUsingContext(TestArray):
+
+    @classmethod
+    def setUpClass(cls):
+        set_blosc_options(use_context=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        set_blosc_options(use_context=False)

--- a/zarr/tests/test_chunk.py
+++ b/zarr/tests/test_chunk.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from zarr.ext import Chunk, PersistentChunk, SynchronizedChunk, \
     SynchronizedPersistentChunk
-from zarr import defaults
+from zarr import defaults, set_blosc_options
 
 
 class ChunkTests(object):
@@ -252,3 +252,14 @@ def test_shuffles():
 
     # expect improvement from bitshuffle
     assert c2.cbytes < c1.cbytes
+
+
+class TestChunkUsingContext(TestChunk):
+
+    @classmethod
+    def setUpClass(cls):
+        set_blosc_options(use_context=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        set_blosc_options(use_context=False)

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -4,14 +4,14 @@ from __future__ import absolute_import, print_function, division
 
 def human_readable_size(size):
     if size < 2**10:
-        return "%s" % size
+        return '%s' % size
     elif size < 2**20:
-        return "%.1fK" % (size / float(2**10))
+        return '%.1fK' % (size / float(2**10))
     elif size < 2**30:
-        return "%.1fM" % (size / float(2**20))
+        return '%.1fM' % (size / float(2**20))
     elif size < 2**40:
-        return "%.1fG" % (size / float(2**30))
+        return '%.1fG' % (size / float(2**30))
     elif size < 2**50:
-        return "%.1fT" % (size / float(2**40))
+        return '%.1fT' % (size / float(2**40))
     else:
-        return "%.1fP" % (size / float(2**50))
+        return '%.1fP' % (size / float(2**50))


### PR DESCRIPTION
This PR resolves #15 by providing the option to use blosc in either contextual or non-contextual mode. The non-contextual mode (now the default) is best when using zarr in a single-threaded environment because it allows blosc to use multiple threads internally. The contextual mode is better when using zarr in a multi-threaded environment like dask.array because it avoids the blosc global lock and so multiple blosc operations can be running concurrently.