### PR TITLE
Implement array attributes

### DIFF
--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+
+import json
+import os
+from threading import Lock
+import fasteners
+
+
+class PersistentAttributes(object):
+
+    def __init__(self, path, mode):
+        self._path = path
+        self._mode = mode
+
+    def __getitem__(self, item):
+
+        if not os.path.exists(self._path):
+            raise KeyError(item)
+
+        with open(self._path, mode='r') as f:
+            return json.load(f)[item]
+
+    def __setitem__(self, key, value):
+
+        # handle read-only state
+        if self._mode == 'r':
+            raise ValueError('array is read-only')
+
+        # load existing data
+        if not os.path.exists(self._path):
+            d = dict()
+        else:
+            with open(self._path, mode='r') as f:
+                d = json.load(f)
+
+        # set key value
+        d[key] = value
+
+        # write modified data
+        with open(self._path, mode='w') as f:
+            json.dump(d, f)
+
+    def __delitem__(self, key):
+
+        # handle read-only state
+        if self._mode == 'r':
+            raise ValueError('array is read-only')
+
+        # load existing data
+        if not os.path.exists(self._path):
+            d = dict()
+        else:
+            with open(self._path, mode='r') as f:
+                d = json.load(f)
+
+        # delete key value
+        del d[key]
+
+        # write modified data
+        with open(self._path, mode='w') as f:
+            json.dump(d, f)
+
+    def asdict(self):
+        if not os.path.exists(self._path):
+            d = dict()
+        else:
+            with open(self._path, mode='r') as f:
+                d = json.load(f)
+        return d
+
+    def __iter__(self):
+        return iter(self.asdict())
+
+    def __len__(self):
+        return len(self.asdict())
+
+    def keys(self):
+        return self.asdict().keys()
+
+    def values(self):
+        return self.asdict().values()
+
+    def items(self):
+        return self.asdict().items()
+
+
+class SynchronizedPersistentAttributes(PersistentAttributes):
+
+    def __init__(self, path, mode):
+        super(SynchronizedPersistentAttributes, self).__init__(path, mode)
+        lock_path = self._path + '.lock'
+        self._thread_lock = Lock()
+        self._file_lock = fasteners.InterProcessLock(lock_path)
+
+    def __getitem__(self, item):
+        with self._thread_lock:
+            with self._file_lock:
+                v = super(SynchronizedPersistentAttributes, self).__getitem__(item)
+                return v
+
+    def __setitem__(self, key, value):
+        with self._thread_lock:
+            with self._file_lock:
+                super(SynchronizedPersistentAttributes, self).__setitem__(key, value)
+
+    def __delitem__(self, key):
+        with self._thread_lock:
+            with self._file_lock:
+                super(SynchronizedPersistentAttributes, self).__delitem__(key)
+
+    def asdict(self):
+        with self._thread_lock:
+            with self._file_lock:
+                return super(SynchronizedPersistentAttributes, self).asdict()

--- a/zarr/defaults.py
+++ b/zarr/defaults.py
@@ -7,6 +7,7 @@ clevel = 5
 shuffle = 1  # byte shuffle
 
 # for persistence
+attrpath = '__zattr__'
 metapath = '__zmeta__'
 datapath = '__zdata__'
 datasuffix = '.blosc'

--- a/zarr/ext.pxd
+++ b/zarr/ext.pxd
@@ -53,6 +53,7 @@ cdef class BaseArray:
     cdef int _clevel
     cdef int _shuffle
     cdef object _fill_value
+    cdef object _attrs
     cdef object _cdata
     # abstract methods
     cdef BaseChunk create_chunk(self, tuple cidx)


### PR DESCRIPTION
Resolves #11 by adding an "attr" property on all arrays with a dict-like interface for storing simple attributes with an array. Includes support for persistence and synchronization.