### PR TITLE
raise AttributeError in __getattr__ if lookup fails

### DIFF
--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -319,7 +319,10 @@ class Group(MutableMapping):
 
     def __getattr__(self, item):
         # allow access to group members via dot notation
-        return self.__getitem__(item)
+        try:
+            return self.__getitem__(item)
+        except KeyError:
+            raise AttributeError
 
     def group_keys(self):
         """Return an iterator over member names for groups only.

--- a/zarr/tests/test_codecs.py
+++ b/zarr/tests/test_codecs.py
@@ -149,6 +149,7 @@ class CodecTests(object):
                                                           order=order)
         assert_array_almost_equal(arr, out, decimal=decimal)
 
+
 test_arrays = [
     np.arange(1000, dtype='i4'),
     np.linspace(1000, 1001, 1000, dtype='f8'),

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -493,7 +493,7 @@ class TestGroup(unittest.TestCase):
         eq(g1['foo'], g1.foo)
         eq(g2['bar'], g2.bar)
         # test that hasattr returns False instead of an exception (issue #88)
-        eq(hasattr(g1, '__unexistingattribute__'), False)
+        assert_false(hasattr(g1, 'unexistingattribute'))
 
     def test_group_repr(self):
         g = self.create_group()

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -492,6 +492,8 @@ class TestGroup(unittest.TestCase):
         # test
         eq(g1['foo'], g1.foo)
         eq(g2['bar'], g2.bar)
+        # test that hasattr returns False instead of an exception (issue #88)
+        eq(hasattr(g1, '__unexistingattribute__'), False)
 
     def test_group_repr(self):
         g = self.create_group()


### PR DESCRIPTION
This fixes #88 by raising an AttributeError instead of a KeyError in __getattr__, which is the more correct thing to do (because hasattr only returns False when it gets an AttributeError, and propagates all other exceptions instead).