### PR TITLE
Fix representation of AsType's dtypes

### DIFF
--- a/zarr/codecs.py
+++ b/zarr/codecs.py
@@ -557,10 +557,10 @@ class AsType(Codec):
 
     def __repr__(self):
         return (
-            '%s(encode_dtype=%s, decode_dtype=%s)' % (
+            '%s(encode_dtype=%r, decode_dtype=%r)' % (
                 type(self).__name__,
-                self.encode_dtype,
-                self.decode_dtype
+                self.encode_dtype.str,
+                self.decode_dtype.str
             )
         )
 

--- a/zarr/tests/test_codecs.py
+++ b/zarr/tests/test_codecs.py
@@ -347,7 +347,7 @@ class TestAsType(CodecTests, unittest.TestCase):
 
     def test_repr(self):
         codec = self.init_codec(encode_dtype='i4', decode_dtype='i8')
-        expect = 'AsType(encode_dtype=int32, decode_dtype=int64)'
+        expect = "AsType(encode_dtype='<i4', decode_dtype='<i8')"
         actual = repr(codec)
         eq(expect, actual)
 


### PR DESCRIPTION
Use string representations of `AsType`'s `dtype`s instead of allowing the `dtype`s to be converted automatically. This matches more closely with what `Delta` is doing in its representation.