### PR TITLE
Support LZMA on Python 2 via backports.lzma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
 
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - liblzma-dev
+
 python:
   - 2.7
   - 3.4

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist = py27, py34, py35, py36, docs
 setenv =
     PYTHONHASHSEED = 42
 commands =
+    py27: pip install -U backports.lzma
     python setup.py build_ext --inplace
     py27,py34,py35: nosetests -v --with-coverage --cover-erase --cover-package=zarr zarr
     py36: nosetests -v --with-coverage --cover-erase --cover-package=zarr --with-doctest --doctest-options=+NORMALIZE_WHITESPACE zarr

--- a/zarr/codecs.py
+++ b/zarr/codecs.py
@@ -241,11 +241,16 @@ class BZ2(Codec):
 codec_registry[BZ2.codec_id] = BZ2
 
 
+lzma = None
 try:
     import lzma
 except ImportError:  # pragma: no cover
-    pass
-else:
+    try:
+        from backports import lzma
+    except ImportError:
+        pass
+
+if lzma:
 
     # noinspection PyShadowingBuiltins
     class LZMA(Codec):

--- a/zarr/tests/test_codecs.py
+++ b/zarr/tests/test_codecs.py
@@ -201,11 +201,16 @@ class TestBZ2(CodecTests, unittest.TestCase):
             self._test_decode_lossless(arr, **config)
 
 
+lzma = None
 try:
     import lzma
 except ImportError:  # pragma: no cover
-    pass
-else:
+    try:
+        from backports import lzma
+    except ImportError:
+        pass
+
+if lzma:
 
     class TestLZMA(CodecTests, unittest.TestCase):
 


### PR DESCRIPTION
Backport(?) of PR ( https://github.com/alimanfoo/numcodecs/pull/13 ).

Tries to use `backports.lzma` as a fallback if `lzma` is not found (e.g. Python 2). Adds testing for it on Travis CI.