### PR TITLE
Unpin setuptools requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 # pinned dependencies for the development and CI environment
-appdirs==1.4.1
+appdirs
 args==0.1.0
 clint==0.5.1
 coverage==4.3.4
@@ -10,7 +10,7 @@ mccabe==0.6.1
 monotonic==1.2
 nose==1.3.7
 numpy==1.12.0
-packaging==16.8
+packaging
 pkginfo==1.4.1
 pluggy==0.4.0
 py==1.4.32
@@ -20,7 +20,7 @@ pyparsing==2.1.10
 requests==2.13.0
 requests-toolbelt==0.7.1
 setuptools-scm==1.15.0
-six==1.10.0
+six
 tox==2.6.0
 twine==1.8.1
 virtualenv==15.1.0


### PR DESCRIPTION
Fixes https://github.com/alimanfoo/zarr/issues/125

As all of these are now requirements of `setuptools` instead of being vendored as they were before, pinning them to anything other than the latest version has adverse consequences. So this drops all of these pins. More details about the problem and possible fixes in issue ( https://github.com/pypa/pip/issues/4264 ).