### PR TITLE
Suppress warning about duplicate write to zip

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -7,6 +7,7 @@ import json
 import zipfile
 import shutil
 import atexit
+import warnings
 
 
 import numpy as np
@@ -830,7 +831,9 @@ class ZipStore(MutableMapping):
         if self.mode == 'r':
             err_read_only()
         value = ensure_bytes(value)
-        self.zf.writestr(key, value)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            self.zf.writestr(key, value)
 
     def __delitem__(self, key):
         raise NotImplementedError

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -8,6 +8,7 @@ import json
 import array
 import shutil
 import os
+import warnings
 
 
 import numpy as np
@@ -644,6 +645,21 @@ class TestZipStore(StoreTests, unittest.TestCase):
         store = ZipStore('example.zip', mode='r')
         with assert_raises(PermissionError):
             store['foo'] = b'bar'
+
+    def test_duplicate(self):
+        caught = False
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            try:
+                with ZipStore('example.zip', mode='w') as store:
+                    store['foo'] = b'bar'
+                    store['foo'] = b'baz'
+            except UserWarning:
+                caught = False
+            else:
+                caught = True
+
+        self.assertTrue(caught, "Failed to catch UserWarning.")
 
 
 def test_getsize():


### PR DESCRIPTION
Fixes https://github.com/alimanfoo/zarr/issues/129

Every time we write data under the same name as an existing dataset, Python's `ZipFile` will raise a `UserWarning`. As they are pretty noisy and there is nothing we can actively do to prevent them, just suppress the warnings to avoid the noise.