### PR TITLE
0-dimensional arrays

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -613,11 +613,15 @@ class Array(object):
         if item not in ((), Ellipsis):
             raise IndexError('too many indices for array')
 
-        # obtain key for chunk storage
-        ckey = self._chunk_key((0,))
-
         # setup data to store
         arr = np.asarray(value, dtype=self._dtype)
+
+        # check value
+        if arr.shape != ():
+            raise ValueError('bad value; expected scalar, found %r' % value)
+
+        # obtain key for chunk storage
+        ckey = self._chunk_key((0,))
 
         # encode and store
         cdata = self._encode_chunk(arr)
@@ -637,7 +641,7 @@ class Array(object):
         if np.isscalar(value):
             pass
         elif expected_shape != value.shape:
-            raise ValueError('value has wrong shape, expecting %s, found %s'
+            raise ValueError('value has wrong shape; expected %s, found %s'
                              % (str(expected_shape),
                                 str(value.shape)))
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -446,7 +446,7 @@ class Array(object):
         if not self._cache_metadata:
             self._load_metadata()
 
-        # handle scalars
+        # handle zero-dimensional arrays
         if self._shape == ():
             return self._getitem_zd(item)
         else:
@@ -600,7 +600,7 @@ class Array(object):
         if not self._cache_metadata:
             self._load_metadata_nosync()
 
-        # handle scalars
+        # handle zero-dimensional arrays
         if self._shape == ():
             return self._setitem_zd(item, value)
         else:

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -448,12 +448,12 @@ class Array(object):
 
         # handle scalars
         if self._shape == ():
-            return self._getitem_scalar(item)
+            return self._getitem_zd(item)
         else:
-            return self._getitem_array(item)
+            return self._getitem_nd(item)
 
-    def _getitem_scalar(self, item):
-        # special case __getitem__ for scalar array
+    def _getitem_zd(self, item):
+        # special case __getitem__ for zero-dimensional array
 
         # check item is valid
         if item not in ((), Ellipsis):
@@ -481,7 +481,8 @@ class Array(object):
 
         return out
 
-    def _getitem_array(self, item):
+    def _getitem_nd(self, item):
+        # implementation of __getitem__ for array with at least one dimension
 
         # normalize selection
         selection = normalize_array_selection(item, self._shape)
@@ -601,12 +602,12 @@ class Array(object):
 
         # handle scalars
         if self._shape == ():
-            return self._setitem_scalar(item, value)
+            return self._setitem_zd(item, value)
         else:
-            return self._setitem_array(item, value)
+            return self._setitem_nd(item, value)
 
-    def _setitem_scalar(self, item, value):
-        # special case __setitem__ for scalar array
+    def _setitem_zd(self, item, value):
+        # special case __setitem__ for zero-dimensional array
 
         # check item is valid
         if item not in ((), Ellipsis):
@@ -622,7 +623,8 @@ class Array(object):
         cdata = self._encode_chunk(arr)
         self.chunk_store[ckey] = cdata
 
-    def _setitem_array(self, item, value):
+    def _setitem_nd(self, item, value):
+        # implementation of __setitem__ for array with at least one dimension
 
         # normalize selection
         selection = normalize_array_selection(item, self._shape)

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -313,8 +313,11 @@ class Array(object):
 
     @property
     def _cdata_shape(self):
-        return tuple(int(np.ceil(s / c))
-                     for s, c in zip(self._shape, self._chunks))
+        if self._shape == ():
+            return (1,)
+        else:
+            return tuple(int(np.ceil(s / c))
+                         for s, c in zip(self._shape, self._chunks))
 
     @property
     def cdata_shape(self):
@@ -460,20 +463,17 @@ class Array(object):
             raise IndexError('too many indices for array')
 
         try:
-
             # obtain encoded data for chunk
             ckey = self._chunk_key((0,))
             cdata = self.chunk_store[ckey]
 
         except KeyError:
-
             # chunk not initialized
             out = np.empty((), dtype=self._dtype)
             if self._fill_value is not None:
                 out.fill(self._fill_value)
 
         else:
-
             out = self._decode_chunk(cdata)
 
         # handle selection of the scalar value via empty tuple

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -320,7 +320,7 @@ def array(data, **kwargs):
     z = create(**kwargs)
 
     # fill with data
-    z[:] = data
+    z[...] = data
 
     return z
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -279,19 +279,23 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
     chunks = normalize_chunks(chunks, shape, dtype.itemsize)
     order = normalize_order(order)
 
-    # obtain compressor config
-    if compressor == 'none':
+    # compressor prep
+    if shape == ():
+        # no point in compressing scalars
+        compressor = None
+    elif compressor == 'none':
         # compatibility
         compressor = None
     elif compressor == 'default':
         compressor = default_compressor
+
+    # obtain compressor config
+    compressor_config = None
     if compressor:
         try:
             compressor_config = compressor.get_config()
         except AttributeError:
             err_bad_compressor(compressor)
-    else:
-        compressor_config = None
 
     # obtain filters config
     if filters:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -281,7 +281,7 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
 
     # compressor prep
     if shape == ():
-        # no point in compressing scalars
+        # no point in compressing a 0-dimensional array, only a single value
         compressor = None
     elif compressor == 'none':
         # compatibility

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -601,10 +601,12 @@ class TestArray(unittest.TestCase):
         eq(a.shape, z.shape)
         eq(a.size, z.size)
         eq(a.dtype, z.dtype)
+        eq(a.nbytes, z.nbytes)
         with assert_raises(TypeError):
             len(z)
         eq((), z.chunks)
         eq(1, z.nchunks)
+        eq((1,), z.cdata_shape)
         # compressor always None - no point in compressing a scalar value
         assert_is_none(z.compressor)
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -630,6 +630,8 @@ class TestArray(unittest.TestCase):
             z[0] = 42
         with assert_raises(IndexError):
             z[:] = 42
+        with assert_raises(ValueError):
+            z[...] = np.array([1, 2, 3])
 
 
 class TestArrayWithPath(TestArray):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -590,7 +590,7 @@ class TestArray(unittest.TestCase):
             z[:, 0] = 42
 
     def test_array_0d(self):
-        # test behaviour for scalars, i.e., array with 0 dimensions
+        # test behaviour for array with 0 dimensions
 
         # setup
         a = np.zeros(())
@@ -607,7 +607,7 @@ class TestArray(unittest.TestCase):
         eq((), z.chunks)
         eq(1, z.nchunks)
         eq((1,), z.cdata_shape)
-        # compressor always None - no point in compressing a scalar value
+        # compressor always None - no point in compressing a single value
         assert_is_none(z.compressor)
 
         # check __getitem__

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -158,6 +158,8 @@ class TestArray(unittest.TestCase):
             assert_array_equal(f[310:], z[310:])
 
     def test_array_1d_set_scalar(self):
+        # test setting the contents of an array with a scalar value
+
         # setup
         a = np.zeros(100)
         z = self.create_array(shape=a.shape, chunks=10, dtype=a.dtype)
@@ -586,6 +588,48 @@ class TestArray(unittest.TestCase):
         # this should error
         with assert_raises(IndexError):
             z[:, 0] = 42
+
+    def test_array_0d(self):
+        # test behaviour for scalars, i.e., array with 0 dimensions
+
+        # setup
+        a = np.zeros(())
+        z = self.create_array(shape=(), dtype=a.dtype, fill_value=0)
+
+        # check properties
+        eq(a.ndim, z.ndim)
+        eq(a.shape, z.shape)
+        eq(a.size, z.size)
+        eq(a.dtype, z.dtype)
+        with assert_raises(TypeError):
+            len(z)
+        eq((), z.chunks)
+        eq(1, z.nchunks)
+        # compressor always None - no point in compressing a scalar value
+        assert_is_none(z.compressor)
+
+        # check __getitem__
+        b = z[...]
+        assert_is_instance(b, np.ndarray)
+        eq(a.shape, b.shape)
+        eq(a.dtype, b.dtype)
+        assert_array_equal(a, np.array(z))
+        assert_array_equal(a, z[...])
+        eq(a[()], z[()])
+        with assert_raises(IndexError):
+            z[0]
+        with assert_raises(IndexError):
+            z[:]
+
+        # check __setitem__
+        z[...] = 42
+        eq(42, z[()])
+        z[()] = 43
+        eq(43, z[()])
+        with assert_raises(IndexError):
+            z[0] = 42
+        with assert_raises(IndexError):
+            z[:] = 42
 
 
 class TestArrayWithPath(TestArray):

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -641,6 +641,10 @@ class TestGroup(unittest.TestCase):
             data = np.arange(200)
             g['foo'] = data
             assert_array_equal(data, g['foo'])
+            # 0d array
+            g['foo'] = 42
+            eq((), g['foo'].shape)
+            eq(42, g['foo'][()])
         except NotImplementedError:
             pass
 


### PR DESCRIPTION
This PR provides tests and implementation of support for 0-dimensional arrays. This builds off work done in #154, however I needed to add special case implementations of ``__getitem__`` and ``__setitem__`` to the ``Array`` class to get indexing working with both empty tuple and ellipsis.