### PR TITLE
Add unicode_type to compat

### DIFF
--- a/zarr/compat.py
+++ b/zarr/compat.py
@@ -11,10 +11,12 @@ if PY2:  # pragma: no cover
 
     text_type = unicode
     binary_type = str
+    unicode_type = unicode
     reduce = reduce
 
 else:
 
     text_type = str
     binary_type = bytes
+    unicode_type = str
     from functools import reduce


### PR DESCRIPTION
Basically provide something that always points to the unicode string type on both Python 2 and Python 3.