### PR TITLE
Collect coverage on all Pythons

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,11 @@ envlist = py27, py34, py35, py36, docs
 setenv =
     PYTHONHASHSEED = 42
 commands =
-    py27,py34,py35: nosetests -v zarr
+    py27,py34,py35: nosetests -v --with-coverage --cover-erase --cover-package=zarr zarr
     py36: nosetests -v --with-coverage --cover-erase --cover-package=zarr --with-doctest --doctest-options=+NORMALIZE_WHITESPACE,+ELLIPSIS zarr
     py36: python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst docs/spec/v2.rst
     py36: flake8 --max-line-length=100 zarr
-    py36: coverage report -m
+    py27,py34,py35,py36: coverage report -m
 deps =
     -rrequirements_dev.txt
 


### PR DESCRIPTION
Seems that Python 2 was getting left out of the mix. However sometimes code needs to be special cased for Python 2. As these branches were not being counted if tested on Python 2, it caused the coverage to dip superficially. Hence this changes tox to track coverage on all Python versions and report the results.