### PR TITLE
Open/save/save/load

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,3 +10,4 @@ API reference
     api/storage
     api/codecs
     api/sync
+    api/convenience

--- a/docs/api/convenience.rst
+++ b/docs/api/convenience.rst
@@ -1,0 +1,8 @@
+Array creation (``zarr.convenience``)
+=====================================
+.. automodule:: zarr.convenience
+.. autofunction:: open
+.. autofunction:: save
+.. autofunction:: load
+.. autofunction:: save_array
+.. autofunction:: save_group

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, docs
+envlist = py27, py35, py36, docs
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,9 @@ commands =
     python -c 'import glob; import shutil; import os; [(shutil.rmtree(d) if os.path.isdir(d) else os.remove(d) if os.path.isfile(d) else None) for d in glob.glob("./example*")]'
     py27,py34,py35: nosetests -v --with-coverage --cover-erase --cover-package=zarr zarr
     py36: nosetests -v --with-coverage --cover-erase --cover-package=zarr --with-doctest --doctest-options=+NORMALIZE_WHITESPACE,+ELLIPSIS zarr
+    coverage report -m
     py36: python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst docs/spec/v2.rst
     py36: flake8 --max-line-length=100 zarr
-    coverage report -m
 deps =
     -rrequirements_dev.txt
 

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -10,5 +10,5 @@ from zarr.storage import DictStore, DirectoryStore, ZipStore, TempStore, NestedD
 from zarr.hierarchy import group, open_group, Group
 from zarr.sync import ThreadSynchronizer, ProcessSynchronizer
 from zarr.codecs import *
-from zarr.convenience import open, save, savez, load
+from zarr.convenience import open, save, save_array, save_group, load
 from zarr.version import version as __version__

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -4,10 +4,11 @@ from __future__ import absolute_import, print_function, division
 
 
 from zarr.core import Array
-from zarr.creation import empty, zeros, ones, full, array, empty_like, zeros_like, ones_like, \
-    full_like, open, open_array, open_like, create
+from zarr.creation import (empty, zeros, ones, full, array, empty_like, zeros_like, ones_like,
+                           full_like, open_array, open_like, create)
 from zarr.storage import DictStore, DirectoryStore, ZipStore, TempStore, NestedDirectoryStore
 from zarr.hierarchy import group, open_group, Group
 from zarr.sync import ThreadSynchronizer, ProcessSynchronizer
 from zarr.codecs import *
+from zarr.convenience import open, save, savez, load
 from zarr.version import version as __version__

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -135,7 +135,10 @@ def savez(store, *args, **kwargs):
     ----------
     store : MutableMapping or string
         Store or path to directory in file system or name of zip file.
-    TODO
+    args : ndarray
+        NumPy arrays with data to save.
+    kwargs
+        NumPy arrays with data to save.
 
     Examples
     --------
@@ -217,12 +220,13 @@ class LazyLoader(Mapping):
         return r
 
 
-def load(store, path=None):
+def load(store):
     """Load data from an array or group into memory using NumPy.
 
     Parameters
     ----------
-    @@TODO
+    store : MutableMapping or string
+        Store or path to directory in file system or name of zip file.
 
     See Also
     --------
@@ -236,9 +240,8 @@ def load(store, path=None):
     """
     # handle polymorphic store arg
     store = normalize_store_arg(store)
-    path = normalize_storage_path(path)
-    if contains_array(store, path):
-        return Array(store=store, path=path)[...]
-    elif contains_group(store, path):
-        grp = Group(store=store, path=path)
+    if contains_array(store, path=None):
+        return Array(store=store, path=None)[...]
+    elif contains_group(store, path=None):
+        grp = Group(store=store, path=None)
         return LazyLoader(grp)

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+from collections import Mapping
+
+
+from zarr.core import Array
+from zarr.creation import open_array, normalize_store_arg, array as _create_array
+from zarr.hierarchy import open_group, group as _create_group, Group
+from zarr.storage import contains_array, contains_group
+from zarr.errors import err_path_not_found
+from zarr.util import normalize_storage_path
+
+
+# noinspection PyShadowingBuiltins
+def open(store, mode='a', **kwargs):
+    """Convenience function to open a group or array using file-mode-like semantics.
+
+    Parameters
+    ----------
+    store : MutableMapping or string
+        Store or path to directory in file system or name of zip file.
+    mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
+        Persistence mode: 'r' means read only (must exist); 'r+' means
+        read/write (must exist); 'a' means read/write (create if doesn't
+        exist); 'w' means create (overwrite if exists); 'w-' means create
+        (fail if exists).
+    **kwargs
+        Additional parameters are passed through to :func:`zarr.open_array` or
+        :func:`zarr.open_group`.
+
+    See Also
+    --------
+    zarr.open_array, zarr.open_group
+
+    Examples
+    --------
+
+    Storing data in a directory 'example.zarr' on the local file system::
+
+        >>> import zarr
+        >>> store = 'example.zarr'
+        >>> zw = zarr.open(store, mode='w', shape=100, dtype='i4')  # open new array
+        >>> zw
+        <zarr.core.Array (100,) int32>
+        >>> za = zarr.open(store, mode='a')  # open existing array for reading and writing
+        >>> za
+        <zarr.core.Array (100,) int32>
+        >>> zr = zarr.open(store, mode='r')  # open existing array read-only
+        >>> zr
+        <zarr.core.Array (100,) int32 read-only>
+        >>> gw = zarr.open(store, mode='w')  # open new group, overwriting any previous data in store
+        >>> gw
+        <zarr.hierarchy.Group '/'>
+        >>> ga = zarr.open(store, mode='a')  # open existing group for reading and writing
+        >>> ga
+        <zarr.hierarchy.Group '/'>
+        >>> gr = zarr.open(store, mode='r')  # open existing group read-only
+        >>> gr
+        <zarr.hierarchy.Group '/' read-only>
+
+    """
+
+    path = kwargs.get('path', None)
+    # handle polymorphic store arg
+    store = normalize_store_arg(store, clobber=(mode == 'w'))
+    path = normalize_storage_path(path)
+
+    if mode in {'w', 'w-', 'x'}:
+        if 'shape' in kwargs:
+            return open_array(store, mode=mode, **kwargs)
+        else:
+            return open_group(store, mode=mode, **kwargs)
+
+    elif mode == 'a':
+        if contains_array(store, path):
+            return open_array(store, mode=mode, **kwargs)
+        elif contains_group(store, path):
+            return open_group(store, mode=mode, **kwargs)
+        elif 'shape' in kwargs:
+            return open_array(store, mode=mode, **kwargs)
+        else:
+            return open_group(store, mode=mode, **kwargs)
+
+    else:
+        if contains_array(store, path):
+            return open_array(store, mode=mode, **kwargs)
+        elif contains_group(store, path):
+            return open_group(store, mode=mode, **kwargs)
+        else:
+            err_path_not_found(path)
+
+
+def save(store, arr, **kwargs):
+    """Convenience function to save a NumPy array to the local file system, following a similar
+    API to the NumPy save() function.
+
+    Parameters
+    ----------
+    store : MutableMapping or string
+        Store or path to directory in file system or name of zip file.
+    arr : ndarray
+        NumPy array with data to save.
+    kwargs
+        Passed through to :func:`create`, e.g., compressor.
+
+    Examples
+    --------
+    Save an array to a directory on the file system (uses a :class:`DirectoryStore`)::
+
+        >>> import zarr
+        >>> import numpy as np
+        >>> arr = np.arange(10000)
+        >>> zarr.save('example.zarr', arr)
+        >>> zarr.load('example.zarr')
+        array([   0,    1,    2, ..., 9997, 9998, 9999])
+
+    Save an array to a single file (uses a :class:`ZipStore`)::
+
+        >>> zarr.save('example.zip', arr)
+        >>> zarr.load('example.zip')
+        array([   0,    1,    2, ..., 9997, 9998, 9999])
+
+    """
+    store = normalize_store_arg(store, clobber=True)
+    _create_array(arr, store=store, overwrite=True, **kwargs)
+    if hasattr(store, 'close'):
+        store.close()
+
+
+def savez(store, *args, **kwargs):
+    """Convenience function to save several NumPy arrays to the local file system, following a
+    similar API to the NumPy savez()/savez_compressed() functions.
+
+    Parameters
+    ----------
+    store : MutableMapping or string
+        Store or path to directory in file system or name of zip file.
+    TODO
+
+    Examples
+    --------
+    Save arrays to a directory on the file system (uses a :class:`DirectoryStore`)::
+
+        >>> import zarr
+        >>> import numpy as np
+        >>> a1 = np.arange(10000)
+        >>> a2 = np.arange(10000, 0, -1)
+        >>> zarr.savez('example.zarr', a1, a2)
+        >>> loader = zarr.load('example.zarr')
+        >>> loader['arr_0']
+        array([   0,    1,    2, ..., 9997, 9998, 9999])
+        >>> loader['arr_1']
+        array([10000,  9999,  9998, ...,     3,     2,     1])
+
+    Save arrays using named keyword arguments::
+
+        >>> zarr.savez('example.zarr', foo=a1, bar=a2)
+        >>> loader = zarr.load('example.zarr')
+        >>> loader['foo']
+        array([   0,    1,    2, ..., 9997, 9998, 9999])
+        >>> loader['bar']
+        array([10000,  9999,  9998, ...,     3,     2,     1])
+
+    Store arrays in a single zip file (uses a :class:`ZipStore`)::
+
+        >>> zarr.savez('example.zip', foo=a1, bar=a2)
+        >>> loader = zarr.load('example.zip')
+        >>> loader['foo']
+        array([   0,    1,    2, ..., 9997, 9998, 9999])
+        >>> loader['bar']
+        array([10000,  9999,  9998, ...,     3,     2,     1])
+
+    Notes
+    -----
+    Default compression options will be used.
+
+    """
+    # handle polymorphic store arg
+    store = normalize_store_arg(store, clobber=True)
+    grp = _create_group(store, overwrite=True)
+    for i, arr in enumerate(args):
+        k = 'arr_{}'.format(i)
+        grp.create_dataset(k, data=arr, overwrite=True)
+    for k, arr in kwargs.items():
+        grp.create_dataset(k, data=arr, overwrite=True)
+    if hasattr(store, 'close'):
+        store.close()
+
+
+class LazyLoader(Mapping):
+
+    def __init__(self, grp):
+        self.grp = grp
+        self.cache = dict()
+
+    def __getitem__(self, item):
+        try:
+            return self.cache[item]
+        except KeyError:
+            arr = self.grp[item][...]
+            self.cache[item] = arr
+            return arr
+
+    def __len__(self):
+        return len(self.grp)
+
+    def __iter__(self):
+        return iter(self.grp)
+
+    def __contains__(self, item):
+        return item in self.grp
+
+    def __repr__(self):
+        r = '<LazyLoader: '
+        r += ', '.join(sorted(self.grp.array_keys()))
+        r += '>'
+        return r
+
+
+def load(store, path=None):
+    """Load data from an array or group into memory using NumPy.
+
+    Parameters
+    ----------
+    @@TODO
+
+    See Also
+    --------
+    save, savez
+
+    Notes
+    -----
+    If loading data from a group of arrays, data will not be immediately loaded into memory.
+    Rather, arrays will be loaded into memory as they are requested.
+
+    """
+    # handle polymorphic store arg
+    store = normalize_store_arg(store)
+    path = normalize_storage_path(path)
+    if contains_array(store, path):
+        return Array(store=store, path=path)[...]
+    elif contains_group(store, path):
+        grp = Group(store=store, path=path)
+        return LazyLoader(grp)

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -48,7 +48,7 @@ def open(store, mode='a', **kwargs):
         >>> zr = zarr.open(store, mode='r')  # open existing array read-only
         >>> zr
         <zarr.core.Array (100,) int32 read-only>
-        >>> gw = zarr.open(store, mode='w')  # open new group, overwriting any previous data in store
+        >>> gw = zarr.open(store, mode='w')  # open new group, overwriting any previous data
         >>> gw
         <zarr.hierarchy.Group '/'>
         >>> ga = zarr.open(store, mode='a')  # open existing group for reading and writing

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1730,6 +1730,8 @@ class Array(object):
             r += ' %r' % self.name
         r += ' %s' % str(self.shape)
         r += ' %s' % self.dtype
+        if self._read_only:
+            r += ' read-only'
         r += '>'
         return r
 

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -34,7 +34,7 @@ def create(shape, chunks=None, dtype=None, compressor='default',
     order : {'C', 'F'}, optional
         Memory layout to be used within each chunk.
     store : MutableMapping or string
-        Store or path to directory in file system.
+        Store or path to directory in file system or name of zip file.
     synchronizer : object, optional
         Array synchronizer.
     overwrite : bool, optional
@@ -345,7 +345,7 @@ def open_array(store, mode='a', shape=None, chunks=None, dtype=None, compressor=
     Parameters
     ----------
     store : MutableMapping or string
-        Store or path to directory in file system.
+        Store or path to directory in file system or name of zip file.
     mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
         Persistence mode: 'r' means read only (must exist); 'r+' means
         read/write (must exist); 'a' means read/write (create if doesn't
@@ -458,10 +458,6 @@ def open_array(store, mode='a', shape=None, chunks=None, dtype=None, compressor=
               cache_metadata=cache_metadata, path=path)
 
     return z
-
-
-# # backwards compatibility
-# open = open_array
 
 
 def _like_args(a, kwargs):

--- a/zarr/errors.py
+++ b/zarr/errors.py
@@ -20,23 +20,23 @@ class MetadataError(Exception):
 
 
 def err_contains_group(path):
-    raise KeyError('path %r contains a group' % path)
+    raise ValueError('path %r contains a group' % path)
 
 
 def err_contains_array(path):
-    raise KeyError('path %r contains an array' % path)
+    raise ValueError('path %r contains an array' % path)
 
 
 def err_array_not_found(path):
-    raise KeyError('array not found at path %r' % path)
+    raise ValueError('array not found at path %r' % path)
 
 
 def err_group_not_found(path):
-    raise KeyError('group not found at path %r' % path)
+    raise ValueError('group not found at path %r' % path)
 
 
 def err_path_not_found(path):
-    raise KeyError('path %r not found' % path)
+    raise ValueError('nothing found at path %r' % path)
 
 
 def err_bad_compressor(compressor):

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -939,7 +939,7 @@ def open_group(store, mode='a', synchronizer=None, path=None):
     Parameters
     ----------
     store : MutableMapping or string
-        Store or path to directory in file system.
+        Store or path to directory in file system or name of zip file.
     mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
         Persistence mode: 'r' means read only (must exist); 'r+' means
         read/write (must exist); 'a' means read/write (create if doesn't

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+import tempfile
+
+
+from nose.tools import assert_raises
+import numpy as np
+from numpy.testing import assert_array_equal
+
+
+from zarr.convenience import open, save, save_group, load
+from zarr.storage import atexit_rmtree
+from zarr.core import Array
+from zarr.hierarchy import Group
+
+
+def test_open_array():
+
+    store = tempfile.mkdtemp()
+    atexit_rmtree(store)
+
+    # open array, create if doesn't exist
+    z = open(store, mode='a', shape=100)
+    assert isinstance(z, Array)
+    assert z.shape == (100,)
+
+    # open array, overwrite
+    z = open(store, mode='w', shape=200)
+    assert isinstance(z, Array)
+    assert z.shape == (200,)
+
+    # open array, read-only
+    z = open(store, mode='r')
+    assert isinstance(z, Array)
+    assert z.shape == (200,)
+    assert z.read_only
+
+    # path not found
+    with assert_raises(ValueError):
+        open('doesnotexist', mode='r')
+
+
+def test_open_group():
+
+    store = tempfile.mkdtemp()
+    atexit_rmtree(store)
+
+    # open group, create if doesn't exist
+    g = open(store, mode='a')
+    g.create_group('foo')
+    assert isinstance(g, Group)
+    assert 'foo' in g
+
+    # open group, overwrite
+    g = open(store, mode='w')
+    assert isinstance(g, Group)
+    assert 'foo' not in g
+
+    # open group, read-only
+    g = open(store, mode='r')
+    assert isinstance(g, Group)
+    assert g.read_only
+
+
+def test_save_errors():
+    with assert_raises(ValueError):
+        # no arrays provided
+        save_group('example.zarr')
+    with assert_raises(ValueError):
+        # no arrays provided
+        save('example.zarr')
+
+
+def test_lazy_loader():
+    foo = np.arange(100)
+    bar = np.arange(100, 0, -1)
+    store = 'example.zarr'
+    save(store, foo=foo, bar=bar)
+    loader = load(store)
+    assert 'foo' in loader
+    assert 'bar' in loader
+    assert 'baz' not in loader
+    assert len(loader) == 2
+    assert sorted(loader) == ['bar', 'foo']
+    assert_array_equal(foo, loader['foo'])
+    assert_array_equal(bar, loader['bar'])

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -50,13 +50,13 @@ class TestArray(unittest.TestCase):
 
         # store not initialized
         store = dict()
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             Array(store)
 
         # group is in the way
         store = dict()
         init_group(store, path='baz')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             Array(store, path='baz')
 
     def create_array(self, read_only=False, **kwargs):

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -189,9 +189,9 @@ def test_open_array():
     # mode in 'r', 'r+'
     open_group('example_group', mode='w')
     for mode in 'r', 'r+':
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_array('doesnotexist', mode=mode)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_array('example_group', mode=mode)
     z = open_array(store, mode='r')
     assert_is_instance(z, Array)
@@ -219,7 +219,7 @@ def test_open_array():
     eq((100,), z.shape)
     eq((10,), z.chunks)
     assert_array_equal(np.full(100, fill_value=42), z[:])
-    with assert_raises(KeyError):
+    with assert_raises(ValueError):
         open_array('example_group', mode='a')
 
     # mode in 'w-', 'x'
@@ -232,9 +232,9 @@ def test_open_array():
         eq((100,), z.shape)
         eq((10,), z.chunks)
         assert_array_equal(np.full(100, fill_value=42), z[:])
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_array(store, mode=mode)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_array('example_group', mode=mode)
 
     # with synchronizer

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -78,14 +78,14 @@ class TestGroup(unittest.TestCase):
     def test_group_init_errors_1(self):
         store, chunk_store = self.create_store()
         # group metadata not initialized
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             Group(store, chunk_store=chunk_store)
 
     def test_group_init_errors_2(self):
         store, chunk_store = self.create_store()
         init_array(store, shape=1000, chunks=100, chunk_store=chunk_store)
         # array blocks group
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             Group(store, chunk_store=chunk_store)
 
     def test_create_group(self):
@@ -137,17 +137,17 @@ class TestGroup(unittest.TestCase):
         eq('test/bytes', go.path)
 
         # test bad keys
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g1.create_group('foo')  # already exists
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g1.create_group('a/b/c')  # already exists
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g4.create_group('/a/b/c')  # already exists
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g1.create_group('')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g1.create_group('/')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g1.create_group('//')
 
         # multi
@@ -321,33 +321,33 @@ class TestGroup(unittest.TestCase):
 
         # array obstructs group, array
         g.create_dataset('foo', shape=100, chunks=10)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.create_group('foo/bar')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.require_group('foo/bar')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.create_dataset('foo/bar', shape=100, chunks=10)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.require_dataset('foo/bar', shape=100, chunks=10)
 
         # array obstructs group, array
         g.create_dataset('a/b', shape=100, chunks=10)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.create_group('a/b')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.require_group('a/b')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.create_dataset('a/b', shape=100, chunks=10)
 
         # group obstructs array
         g.create_group('c/d')
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.create_dataset('c', shape=100, chunks=10)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.require_dataset('c', shape=100, chunks=10)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.create_dataset('c/d', shape=100, chunks=10)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             g.require_dataset('c/d', shape=100, chunks=10)
 
         # h5py compatibility, accept 'fillvalue'
@@ -876,7 +876,7 @@ def test_group():
     # overwrite behaviour
     store = dict()
     init_array(store, shape=100, chunks=10)
-    with assert_raises(KeyError):
+    with assert_raises(ValueError):
         group(store)
     g = group(store, overwrite=True)
     assert_is_instance(g, Group)
@@ -899,9 +899,9 @@ def test_open_group():
     # mode in 'r', 'r+'
     open_array('example_array', shape=100, chunks=10, mode='w')
     for mode in 'r', 'r+':
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_group('doesnotexist', mode=mode)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_group('example_array', mode=mode)
     g = open_group(store, mode='r')
     assert_is_instance(g, Group)
@@ -922,7 +922,7 @@ def test_open_group():
     eq(0, len(g))
     g.create_groups('foo', 'bar')
     eq(2, len(g))
-    with assert_raises(KeyError):
+    with assert_raises(ValueError):
         open_group('example_array', mode='a')
 
     # mode in 'w-', 'x'
@@ -934,9 +934,9 @@ def test_open_group():
         eq(0, len(g))
         g.create_groups('foo', 'bar')
         eq(2, len(g))
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_group(store, mode=mode)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             open_group('example_array', mode=mode)
 
     # open with path

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -172,17 +172,17 @@ class StoreTests(object):
             eq(6, store.getsize('c/e'))
             eq(3, store.getsize('c/e/f'))
             eq(3, store.getsize('c/e/g'))
-            with assert_raises(KeyError):
+            with assert_raises(ValueError):
                 store.getsize('x')
-            with assert_raises(KeyError):
+            with assert_raises(ValueError):
                 store.getsize('a/x')
-            with assert_raises(KeyError):
+            with assert_raises(ValueError):
                 store.getsize('c/x')
-            with assert_raises(KeyError):
+            with assert_raises(ValueError):
                 store.getsize('c/x/y')
-            with assert_raises(KeyError):
+            with assert_raises(ValueError):
                 store.getsize('c/d/y')
-            with assert_raises(KeyError):
+            with assert_raises(ValueError):
                 store.getsize('c/d/y/z')
 
         # test listdir (optional)
@@ -257,7 +257,7 @@ class StoreTests(object):
         )
 
         # don't overwrite (default)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_array(store, shape=1000, chunks=100)
 
         # do overwrite
@@ -310,7 +310,7 @@ class StoreTests(object):
         store[path + '/' + array_meta_key] = encode_array_metadata(meta)
 
         # don't overwrite
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_array(store, shape=1000, chunks=100, path=path)
 
         # do overwrite
@@ -337,7 +337,7 @@ class StoreTests(object):
         store[path + '/' + group_meta_key] = encode_group_metadata()
 
         # don't overwrite
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_array(store, shape=1000, chunks=100, path=path)
 
         # do overwrite
@@ -372,7 +372,7 @@ class StoreTests(object):
         chunk_store['1'] = b'bbb'
 
         # don't overwrite (default)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_array(store, shape=1000, chunks=100, chunk_store=chunk_store)
 
         # do overwrite
@@ -424,7 +424,7 @@ class StoreTests(object):
         )
 
         # don't overwrite array (default)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_group(store)
 
         # do overwrite
@@ -439,7 +439,7 @@ class StoreTests(object):
             eq(ZARR_FORMAT, meta['zarr_format'])
 
         # don't overwrite group
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_group(store)
 
     def test_init_group_overwrite_path(self):
@@ -457,7 +457,7 @@ class StoreTests(object):
         store[path + '/' + array_meta_key] = encode_array_metadata(meta)
 
         # don't overwrite
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_group(store, path=path)
 
         # do overwrite
@@ -491,7 +491,7 @@ class StoreTests(object):
         chunk_store['baz'] = b'quux'
 
         # don't overwrite array (default)
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_group(store, chunk_store=chunk_store)
 
         # do overwrite
@@ -508,7 +508,7 @@ class StoreTests(object):
             assert 'baz' not in chunk_store
 
         # don't overwrite group
-        with assert_raises(KeyError):
+        with assert_raises(ValueError):
             init_group(store)
 
 


### PR DESCRIPTION
This PR adds some convenience functions for opening/loading/saving data to different storage.

* Function ``zarr.open`` will now open either array or group, depending on what it finds (resolves #105).
* Function ``zarr.save`` added, similar API to ``numpy.save/savez`` (resolves #104).
* Function ``zarr.load`` added, similar API to ``numpy.load``.

All functions will also now detect a string ending '.zip' passed as the ``store`` argument and use a ``ZipStore`` (resolves #141).
