### PR TITLE
No chunks

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -13,7 +13,7 @@ from numcodecs.registry import codec_registry
 from zarr.errors import err_contains_array, err_contains_group, err_array_not_found
 
 
-def create(shape, chunks=None, dtype=None, compressor='default',
+def create(shape, chunks=True, dtype=None, compressor='default',
            fill_value=0, order='C', store=None, synchronizer=None,
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, read_only=False, **kwargs):
@@ -24,7 +24,8 @@ def create(shape, chunks=None, dtype=None, compressor='default',
     shape : int or tuple of ints
         Array shape.
     chunks : int or tuple of ints, optional
-        Chunk shape. If not provided, will be guessed from `shape` and `dtype`.
+        Chunk shape. If True, will be guessed from `shape` and `dtype`. If
+        False, will be set to `shape`, i.e., single chunk for the whole array.
     dtype : string or dtype, optional
         NumPy dtype.
     compressor : Codec, optional
@@ -337,7 +338,7 @@ def array(data, **kwargs):
     return z
 
 
-def open_array(store, mode='a', shape=None, chunks=None, dtype=None, compressor='default',
+def open_array(store, mode='a', shape=None, chunks=True, dtype=None, compressor='default',
                fill_value=0, order='C', synchronizer=None, filters=None, cache_metadata=True,
                path=None, **kwargs):
     """Open an array using file-mode-like semantics.
@@ -354,7 +355,8 @@ def open_array(store, mode='a', shape=None, chunks=None, dtype=None, compressor=
     shape : int or tuple of ints, optional
         Array shape.
     chunks : int or tuple of ints, optional
-        Chunk shape. If not provided, will be guessed from `shape` and `dtype`.
+        Chunk shape. If True, will be guessed from `shape` and `dtype`. If
+        False, will be set to `shape`, i.e., single chunk for the whole array.
     dtype : string or dtype, optional
         NumPy dtype.
     compressor : Codec, optional

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -143,7 +143,7 @@ def _require_parent_group(path, store, chunk_store, overwrite):
                 _init_group_metadata(store, path=p, chunk_store=chunk_store)
 
 
-def init_array(store, shape, chunks=None, dtype=None, compressor='default',
+def init_array(store, shape, chunks=True, dtype=None, compressor='default',
                fill_value=None, order='C', overwrite=False, path=None,
                chunk_store=None, filters=None):
     """initialize an array store with the given configuration.
@@ -155,7 +155,8 @@ def init_array(store, shape, chunks=None, dtype=None, compressor='default',
     shape : int or tuple of ints
         Array shape.
     chunks : int or tuple of ints, optional
-        Chunk shape. If not provided, will be guessed from `shape` and `dtype`.
+        Chunk shape. If True, will be guessed from `shape` and `dtype`. If
+        False, will be set to `shape`, i.e., single chunk for the whole array.
     dtype : string or dtype, optional
         NumPy dtype.
     compressor : Codec, optional

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -427,6 +427,15 @@ def test_create():
         # bad fill value
         create(100, dtype='i4', fill_value='foo')
 
+    # auto chunks
+    z = create(1000000000, chunks=True)
+    assert z.chunks[0] < z.shape[0]
+    z = create(1000000000, chunks=None)  # backwards-compatibility
+    assert z.chunks[0] < z.shape[0]
+    # no chunks
+    z = create(1000000000, chunks=False)
+    assert z.chunks == z.shape
+
 
 def test_compression_args():
     warnings.resetwarnings()

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -89,6 +89,10 @@ def normalize_chunks(chunks, shape, typesize):
     if chunks is None or chunks is True:
         return guess_chunks(shape, typesize)
 
+    # handle no chunking
+    if chunks is False:
+        return shape
+
     # handle 1D convenience form
     if isinstance(chunks, numbers.Integral):
         chunks = (int(chunks),)


### PR DESCRIPTION
This PR resolves #106. For symmetry and backwards compatibility, I've gone for the following:
* chunks=True triggers auto-chunking
* chunks=False means no chunks, i.e., shape of array will be used for value of chunks, i.e., one chunk for whole array
* chunks=None also triggers auto-chunking for backwards compabitility