### PR TITLE
Use jstree

### DIFF
--- a/notebooks/repr_tree.ipynb
+++ b/notebooks/repr_tree.ipynb
@@ -6,13 +6,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import zarr\n",
-    "\n",
-    "# Python 2/3 trick\n",
-    "try:\n",
-    "    unicode\n",
-    "except NameError:\n",
-    "    unicode = str"
+    "import sys\n",
+    "sys.path.insert(0, '..')\n",
+    "import zarr"
    ]
   },
   {
@@ -22,10 +18,14 @@
    "outputs": [],
    "source": [
     "g1 = zarr.group()\n",
+    "g2 = g1.create_group('foo')\n",
     "g3 = g1.create_group('bar')\n",
     "g3.create_group('baz')\n",
+    "g3.create_dataset('xxx', shape=100)\n",
+    "g3.create_dataset('yyy', shape=(100, 100), dtype='i4')\n",
     "g5 = g3.create_group('quux')\n",
-    "g5.create_dataset('baz', shape=100, chunks=10)\n",
+    "g5.create_dataset('aaa', shape=100)\n",
+    "g5.create_dataset('bbb', shape=(100, 100), dtype='i4')\n",
     "g7 = g3.create_group('zoo')"
    ]
   },
@@ -39,16 +39,20 @@
      "output_type": "stream",
      "text": [
       "/\n",
-      " +-- bar\n",
-      "     +-- baz\n",
-      "     +-- quux\n",
-      "     |   +-- baz[...]\n",
-      "     +-- zoo\n"
+      " ├── bar\n",
+      " │   ├── baz\n",
+      " │   ├── quux\n",
+      " │   │   ├── aaa (100,) float64\n",
+      " │   │   └── bbb (100, 100) int32\n",
+      " │   ├── xxx (100,) float64\n",
+      " │   ├── yyy (100, 100) int32\n",
+      " │   └── zoo\n",
+      " └── foo\n"
      ]
     }
    ],
    "source": [
-    "print(bytes(g1.tree()).decode())"
+    "print(g1.tree())"
    ]
   },
   {
@@ -60,16 +64,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "bar\n",
-      " ├── baz\n",
-      " ├── quux\n",
-      " │   └── baz[...]\n",
-      " └── zoo\n"
+      "/\n",
+      " ├── bar\n",
+      " └── foo\n"
      ]
     }
    ],
    "source": [
-    "print(unicode(g3.tree()))"
+    "print(g1.tree(level=1))"
    ]
   },
   {
@@ -78,98 +80,342 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/\n",
+      " ├── bar\n",
+      " │   ├── baz\n",
+      " │   ├── quux\n",
+      " │   ├── xxx (100,) float64\n",
+      " │   ├── yyy (100, 100) int32\n",
+      " │   └── zoo\n",
+      " └── foo\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(g1.tree(level=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/\n",
+      " +-- bar\n",
+      " |   +-- baz\n",
+      " |   +-- quux\n",
+      " |   |   +-- aaa (100,) float64\n",
+      " |   |   +-- bbb (100, 100) int32\n",
+      " |   +-- xxx (100,) float64\n",
+      " |   +-- yyy (100, 100) int32\n",
+      " |   +-- zoo\n",
+      " +-- foo\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(bytes(g1.tree()).decode())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "text/html": [
-       "<style type=\"text/css\">\n",
-       "div.zarr-tree {\n",
-       "    font-family: Courier, monospace;\n",
-       "    font-size: 11pt;\n",
-       "    font-style: normal;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree ul,\n",
-       "div.zarr-tree li,\n",
-       "div.zarr-tree li > div {\n",
-       "    display: block;\n",
-       "    position: relative;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree ul,\n",
-       "div.zarr-tree li {\n",
-       "    list-style-type: none;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree li {\n",
-       "    border-left: 2px solid #000;\n",
-       "    margin-left: 1em;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree li > div {\n",
-       "    padding-left: 1.3em;\n",
-       "    padding-top: 0.225em;\n",
-       "    padding-bottom: 0.225em;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree li > div::before {\n",
-       "    content: '';\n",
-       "    position: absolute;\n",
-       "    top: 0;\n",
-       "    left: -2px;\n",
-       "    bottom: 50%;\n",
-       "    width: 1.2em;\n",
-       "    border-left: 2px solid #000;\n",
-       "    border-bottom: 2px solid #000;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree > ul > li:first-child > div {\n",
-       "    padding-left: 4%;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree > ul > li:first-child > div::before {\n",
-       "    border: 0 none transparent;\n",
-       "}\n",
-       "\n",
-       "div.zarr-tree ul > li:last-child {\n",
-       "    border-left: 2px solid transparent;\n",
-       "}\n",
-       "</style>\n",
-       "\n",
-       "<div class=\"zarr-tree\">\n",
-       "<ul>\n",
-       "    <li><div>/</div>\n",
-       "        <ul>\n",
-       "            <li><div>bar</div>\n",
-       "                <ul>\n",
-       "                    <li><div>baz</div></li>\n",
-       "                    <li><div>quux</div>\n",
-       "                        <ul>\n",
-       "                            <li><div>baz[...]</div></li>\n",
-       "                        </ul>\n",
-       "                    </li>\n",
-       "                    <li><div>zoo</div></li>\n",
-       "                </ul>\n",
-       "            </li>\n",
-       "        </ul>\n",
-       "    </li>\n",
-       "</ul>\n",
-       "</div>\n"
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"fd4f29b9-7041-4a1a-99e7-670f7c794e5e\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#fd4f29b9-7041-4a1a-99e7-670f7c794e5e').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>         \n"
       ],
       "text/plain": [
        "/\n",
-       " └── bar\n",
-       "     ├── baz\n",
-       "     ├── quux\n",
-       "     │   └── baz[...]\n",
-       "     └── zoo"
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   │   ├── aaa (100,) float64\n",
+       " │   │   └── bbb (100, 100) int32\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "g1.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"f6b51452-981e-49d5-b0fe-0926b41c88fa\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#f6b51452-981e-49d5-b0fe-0926b41c88fa').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>         \n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   │   ├── aaa (100,) float64\n",
+       " │   │   └── bbb (100, 100) int32\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"5ae96b77-935e-4b30-8e72-81dd5039cb40\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#5ae96b77-935e-4b30-8e72-81dd5039cb40').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>         \n"
+      ],
+      "text/plain": [
+       "bar\n",
+       " ├── baz\n",
+       " ├── quux\n",
+       " │   ├── aaa (100,) float64\n",
+       " │   └── bbb (100, 100) int32\n",
+       " ├── xxx (100,) float64\n",
+       " ├── yyy (100, 100) int32\n",
+       " └── zoo"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g3.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"75e0a242-e656-45e4-8d6f-826ac746f4ab\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#75e0a242-e656-45e4-8d6f-826ac746f4ab').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>         \n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=True, level=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"022afa56-ae4a-453c-8f42-304d6160f3e6\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#022afa56-ae4a-453c-8f42-304d6160f3e6').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>         \n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=True, level=1)"
    ]
   },
   {
@@ -196,7 +442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/repr_tree.ipynb
+++ b/notebooks/repr_tree.ipynb
@@ -132,7 +132,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"fd4f29b9-7041-4a1a-99e7-670f7c794e5e\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>foo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"dd9e6a7a-180c-425a-ae66-ec1967809191\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -149,7 +149,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#fd4f29b9-7041-4a1a-99e7-670f7c794e5e').jstree({\n",
+       "        $('#dd9e6a7a-180c-425a-ae66-ec1967809191').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -161,7 +161,7 @@
        "            plugins: [\"types\"]\n",
        "        });\n",
        "    });\n",
-       "</script>         \n"
+       "</script>\n"
       ],
       "text/plain": [
        "/\n",
@@ -193,7 +193,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"f6b51452-981e-49d5-b0fe-0926b41c88fa\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"d9928cca-0968-45c4-ac4d-a1ba907249cc\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -210,7 +210,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#f6b51452-981e-49d5-b0fe-0926b41c88fa').jstree({\n",
+       "        $('#d9928cca-0968-45c4-ac4d-a1ba907249cc').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -222,7 +222,7 @@
        "            plugins: [\"types\"]\n",
        "        });\n",
        "    });\n",
-       "</script>         \n"
+       "</script>\n"
       ],
       "text/plain": [
        "/\n",
@@ -254,7 +254,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"5ae96b77-935e-4b30-8e72-81dd5039cb40\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"60c75c42-0141-4f47-b099-1891e7628f67\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -271,7 +271,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#5ae96b77-935e-4b30-8e72-81dd5039cb40').jstree({\n",
+       "        $('#60c75c42-0141-4f47-b099-1891e7628f67').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -283,7 +283,7 @@
        "            plugins: [\"types\"]\n",
        "        });\n",
        "    });\n",
-       "</script>         \n"
+       "</script>\n"
       ],
       "text/plain": [
        "bar\n",
@@ -313,7 +313,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"75e0a242-e656-45e4-8d6f-826ac746f4ab\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"ad67df87-3192-42c8-83a0-bbbe53f16b75\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -330,7 +330,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#75e0a242-e656-45e4-8d6f-826ac746f4ab').jstree({\n",
+       "        $('#ad67df87-3192-42c8-83a0-bbbe53f16b75').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -342,7 +342,7 @@
        "            plugins: [\"types\"]\n",
        "        });\n",
        "    });\n",
-       "</script>         \n"
+       "</script>\n"
       ],
       "text/plain": [
        "/\n",
@@ -372,7 +372,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"022afa56-ae4a-453c-8f42-304d6160f3e6\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"11f743cf-62cd-4b07-ab98-563accd1ba77\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -389,7 +389,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#022afa56-ae4a-453c-8f42-304d6160f3e6').jstree({\n",
+       "        $('#11f743cf-62cd-4b07-ab98-563accd1ba77').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -401,7 +401,7 @@
        "            plugins: [\"types\"]\n",
        "        });\n",
        "    });\n",
-       "</script>         \n"
+       "</script>\n"
       ],
       "text/plain": [
        "/\n",

--- a/notebooks/repr_tree.ipynb
+++ b/notebooks/repr_tree.ipynb
@@ -4,11 +4,21 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2.1.5.dev211'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "import sys\n",
-    "sys.path.insert(0, '..')\n",
-    "import zarr"
+    "import zarr\n",
+    "zarr.__version__"
    ]
   },
   {
@@ -27,6 +37,13 @@
     "g5.create_dataset('aaa', shape=100)\n",
     "g5.create_dataset('bbb', shape=(100, 100), dtype='i4')\n",
     "g7 = g3.create_group('zoo')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate text (unicode) tree:"
    ]
   },
   {
@@ -53,6 +70,13 @@
    ],
    "source": [
     "print(g1.tree())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``level`` parameter controls how deep the tree is."
    ]
   },
   {
@@ -99,6 +123,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternative plain ASCII tree:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
@@ -125,6 +156,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HTML trees:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
@@ -132,7 +170,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"dd9e6a7a-180c-425a-ae66-ec1967809191\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>foo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"c10a67fc-726d-40fa-ab44-076852f671de\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -149,7 +187,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#dd9e6a7a-180c-425a-ae66-ec1967809191').jstree({\n",
+       "        $('#c10a67fc-726d-40fa-ab44-076852f671de').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -186,6 +224,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use ``expand=True`` to have all groups automatically expanded."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
@@ -193,7 +238,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"d9928cca-0968-45c4-ac4d-a1ba907249cc\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"26191d7d-11f9-420b-ae00-ba1f9b5691de\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -210,7 +255,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#d9928cca-0968-45c4-ac4d-a1ba907249cc').jstree({\n",
+       "        $('#26191d7d-11f9-420b-ae00-ba1f9b5691de').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -254,7 +299,7 @@
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"60c75c42-0141-4f47-b099-1891e7628f67\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"c5eac109-b90a-4a76-9a64-62093d573b9a\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -271,66 +316,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#60c75c42-0141-4f47-b099-1891e7628f67').jstree({\n",
-       "            types: {\n",
-       "                Group: {\n",
-       "                    icon: \"fa fa-folder\"\n",
-       "                },\n",
-       "                Array: {\n",
-       "                    icon: \"fa fa-table\"\n",
-       "                }\n",
-       "            },\n",
-       "            plugins: [\"types\"]\n",
-       "        });\n",
-       "    });\n",
-       "</script>\n"
-      ],
-      "text/plain": [
-       "bar\n",
-       " ├── baz\n",
-       " ├── quux\n",
-       " │   ├── aaa (100,) float64\n",
-       " │   └── bbb (100, 100) int32\n",
-       " ├── xxx (100,) float64\n",
-       " ├── yyy (100, 100) int32\n",
-       " └── zoo"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "g3.tree()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"ad67df87-3192-42c8-83a0-bbbe53f16b75\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
-       "<script>\n",
-       "    if (!require.defined('jquery')) {\n",
-       "        require.config({\n",
-       "            paths: {\n",
-       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
-       "            },\n",
-       "        });\n",
-       "    }\n",
-       "    if (!require.defined('jstree')) {\n",
-       "        require.config({\n",
-       "            paths: {\n",
-       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
-       "            },\n",
-       "        });\n",
-       "    }\n",
-       "    require(['jstree'], function() {\n",
-       "        $('#ad67df87-3192-42c8-83a0-bbbe53f16b75').jstree({\n",
+       "        $('#c5eac109-b90a-4a76-9a64-62093d573b9a').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -355,7 +341,7 @@
        " └── foo"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,13 +352,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"11f743cf-62cd-4b07-ab98-563accd1ba77\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"5cdb1a42-eee5-4d44-8483-94c28904573c\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
        "<script>\n",
        "    if (!require.defined('jquery')) {\n",
        "        require.config({\n",
@@ -389,7 +375,7 @@
        "        });\n",
        "    }\n",
        "    require(['jstree'], function() {\n",
-       "        $('#11f743cf-62cd-4b07-ab98-563accd1ba77').jstree({\n",
+       "        $('#5cdb1a42-eee5-4d44-8483-94c28904573c').jstree({\n",
        "            types: {\n",
        "                Group: {\n",
        "                    icon: \"fa fa-folder\"\n",
@@ -409,13 +395,359 @@
        " └── foo"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "g1.tree(expand=True, level=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``expand`` parameter can also be an integer, giving the depth to expand to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"3edbc117-0831-45b6-9990-1da5f33e1f68\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#3edbc117-0831-45b6-9990-1da5f33e1f68').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   │   ├── aaa (100,) float64\n",
+       " │   │   └── bbb (100, 100) int32\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"67944974-e23a-40f6-b33c-174e3253101d\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class=''><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class=''><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#67944974-e23a-40f6-b33c-174e3253101d').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   │   ├── aaa (100,) float64\n",
+       " │   │   └── bbb (100, 100) int32\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"3e1bdd6d-b61f-4508-a4f8-af5b45e91556\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class=''><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class=''><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#3e1bdd6d-b61f-4508-a4f8-af5b45e91556').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-table\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   │   ├── aaa (100,) float64\n",
+       " │   │   └── bbb (100, 100) int32\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Change default icons, use icons from jstree default theme:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr.util.tree_array_icon = 'jstree-file'\n",
+    "zarr.util.tree_group_icon = 'jstree-folder'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"7ebbd81a-85bd-4b43-a2cf-d60ada34440a\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#7ebbd81a-85bd-4b43-a2cf-d60ada34440a').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"jstree-folder\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"jstree-file\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   │   ├── aaa (100,) float64\n",
+       " │   │   └── bbb (100, 100) int32\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Change default icons, use font awesome icons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr.util.tree_array_icon = 'fa fa-space-shuttle'\n",
+    "zarr.util.tree_group_icon = 'fa fa-star-o'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css\"/><div id=\"6eed02c5-813f-44d9-b2f3-0831b7f20747\" class=\"zarr-tree\"><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>/</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>bar</span><ul><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>baz</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>quux</span><ul><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>aaa (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>bbb (100, 100) int32</span></li></ul></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>xxx (100,) float64</span></li><li data-jstree='{\"type\": \"Array\"}' class='jstree-open'><span>yyy (100, 100) int32</span></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>zoo</span></li></ul></li><li data-jstree='{\"type\": \"Group\"}' class='jstree-open'><span>foo</span></li></ul></li></ul></div>\n",
+       "<script>\n",
+       "    if (!require.defined('jquery')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    if (!require.defined('jstree')) {\n",
+       "        require.config({\n",
+       "            paths: {\n",
+       "                jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'\n",
+       "            },\n",
+       "        });\n",
+       "    }\n",
+       "    require(['jstree'], function() {\n",
+       "        $('#6eed02c5-813f-44d9-b2f3-0831b7f20747').jstree({\n",
+       "            types: {\n",
+       "                Group: {\n",
+       "                    icon: \"fa fa-star-o\"\n",
+       "                },\n",
+       "                Array: {\n",
+       "                    icon: \"fa fa-space-shuttle\"\n",
+       "                }\n",
+       "            },\n",
+       "            plugins: [\"types\"]\n",
+       "        });\n",
+       "    });\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "/\n",
+       " ├── bar\n",
+       " │   ├── baz\n",
+       " │   ├── quux\n",
+       " │   │   ├── aaa (100,) float64\n",
+       " │   │   └── bbb (100, 100) int32\n",
+       " │   ├── xxx (100,) float64\n",
+       " │   ├── yyy (100, 100) int32\n",
+       " │   └── zoo\n",
+       " └── foo"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g1.tree(expand=True)"
    ]
   },
   {

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -546,8 +546,15 @@ class Group(MutableMapping):
         base_len = len(self.name)
         return self.visitvalues(lambda o: func(o.name[base_len:].lstrip("/"), o))
 
-    def tree(self):
+    def tree(self, expand=False, level=None):
         """Provide a ``print``-able display of the hierarchy.
+
+        Parameters
+        ----------
+        expand : bool, optional
+            Only relevant for HTML representation. If True, tree will be fully expanded.
+        level : int, optional
+            Maximum depth to descend into hierarchy.
 
         Examples
         --------
@@ -558,21 +565,28 @@ class Group(MutableMapping):
         >>> g4 = g3.create_group('baz')
         >>> g5 = g3.create_group('quux')
         >>> d1 = g5.create_dataset('baz', shape=100, chunks=10)
-        >>> print(g1.tree())
+        >>> g1.tree()
         /
          ├── bar
          │   ├── baz
          │   └── quux
-         │       └── baz[...]
+         │       └── baz (100,) float64
          └── foo
-        >>> print(g3.tree())
+        >>> g1.tree(level=2)
+        /
+         ├── bar
+         │   ├── baz
+         │   └── quux
+         └── foo
+        >>> g3.tree()
         bar
          ├── baz
          └── quux
-             └── baz[...]
+             └── baz (100,) float64
+
         """
 
-        return TreeViewer(self)
+        return TreeViewer(self, expand=expand, level=level)
 
     def _write_op(self, f, *args, **kwargs):
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -414,7 +414,7 @@ def tree_html(group, expand, level):
                     plugins: ["types"]
                 });
             });
-        </script>         
+        </script>
     """ % (node_id, tree_group_icon, tree_array_icon))
 
     return result

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -353,7 +353,10 @@ class TreeTraversal(Traversal):
 def tree_html_sublist(node, root=False, expand=False):
     result = ''
     data_jstree = '{"type": "%s"}' % node.get_type()
-    css_class = 'jstree-open' if (root or expand) else ''
+    if root or (expand is True) or (isinstance(expand, int) and node.depth < expand):
+        css_class = 'jstree-open'
+    else:
+        css_class = ''
     result += "<li data-jstree='{}' class='{}'>".format(data_jstree, css_class)
     result += '<span>{}</span>'.format(node.get_text())
     children = node.get_children()

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import, print_function, division
 import operator
 from textwrap import TextWrapper, dedent
 import numbers
+import uuid
+
 
 from asciitree import BoxStyle, LeftAligned
 from asciitree.traversal import Traversal
-
 import numpy as np
 
 
@@ -312,117 +313,127 @@ class InfoReporter(object):
         return info_html_report(items)
 
 
-class ZarrGroupTraversal(Traversal):
+class TreeNode(object):
+
+    def __init__(self, obj, depth=0, level=None):
+        self.obj = obj
+        self.depth = depth
+        self.level = level
+
+    def get_children(self):
+        if hasattr(self.obj, 'values'):
+            if self.level is None or self.depth < self.level:
+                depth = self.depth + 1
+                return [TreeNode(o, depth=depth, level=self.level)
+                        for o in self.obj.values()]
+        return []
+
+    def get_text(self):
+        name = self.obj.name.split("/")[-1] or "/"
+        if hasattr(self.obj, 'shape'):
+            name += ' {} {}'.format(self.obj.shape, self.obj.dtype)
+        return name
+
+    def get_type(self):
+        return type(self.obj).__name__
+
+
+class ZarrTraversal(Traversal):
 
     def get_children(self, node):
-        return getattr(node, "values", lambda: [])()
+        return node.get_children()
 
     def get_root(self, tree):
         return tree
 
     def get_text(self, node):
-        name = node.name.split("/")[-1] or "/"
-        name += "[...]" if hasattr(node, "dtype") else ""
-        return name
+        return node.get_text()
 
 
-def custom_html_sublist(group, indent):
-    traverser = ZarrGroupTraversal(tree=group)
-    result = ""
-
-    result += (
-        """{0}<li><div>{1}</div>""".format(
-            indent, traverser.get_text(group)
-        )
-    )
-
-    children = traverser.get_children(group)
+def tree_html_sublist(node, root=False, expand=False):
+    traverser = ZarrTraversal(tree=node)
+    result = ''
+    data_jstree = '{"type": "%s"}' % node.get_type()
+    css_class = 'jstree-open' if (root or expand) else ''
+    result += "<li data-jstree='{}' class='{}'>".format(data_jstree, css_class)
+    result += '<span>{}</span>'.format(traverser.get_text(node))
+    children = traverser.get_children(node)
     if children:
-        result += """\n{0}{0}<ul>\n""".format(indent)
+        result += '<ul>'
         for c in children:
-            for l in custom_html_sublist(c, indent).splitlines():
-                result += "{0}{0}{1}\n".format(indent, l)
-        result += "{0}{0}</ul>\n{0}".format(indent)
+            result += tree_html_sublist(c, expand=expand)
+        result += '</ul>'
+    result += '</li>'
+    return result
 
-    result += "</li>\n"
+
+def tree_html(group, expand, level):
+
+    result = ''
+
+    # include CSS for jstree default theme
+    css_url = '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/themes/default/style.min.css'
+    result += '<link rel="stylesheet" href="{}"/>'.format(css_url)
+
+    # construct the tree as HTML nested lists
+    node_id = uuid.uuid4()
+    result += '<div id="{}" class="zarr-tree">'.format(node_id)
+    result += '<ul>'
+    root = TreeNode(group, level=level)
+    result += tree_html_sublist(root, root=True, expand=expand)
+    result += '</ul>'
+    result += '</div>'
+
+    # construct javascript
+    result += dedent("""
+        <script>
+            if (!require.defined('jquery')) {
+                require.config({
+                    paths: {
+                        jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min'
+                    },
+                });
+            }
+            if (!require.defined('jstree')) {
+                require.config({
+                    paths: {
+                        jstree: '//cdnjs.cloudflare.com/ajax/libs/jstree/3.3.3/jstree.min'
+                    },
+                });
+            }
+            require(['jstree'], function() {
+                $('#%s').jstree({
+                    types: {
+                        Group: {
+                            icon: "%s"
+                        },
+                        Array: {
+                            icon: "%s"
+                        }
+                    },
+                    plugins: ["types"]
+                });
+            });
+        </script>         
+    """ % (node_id, tree_group_icon, tree_array_icon))
 
     return result
 
 
-def custom_html_list(group, indent="    "):
-    result = ""
-
-    # Add custom CSS style for our HTML list
-    result += """<style type="text/css">\n"""
-    result += dedent("""\
-        div.zarr-tree {
-            font-family: Courier, monospace;
-            font-size: 11pt;
-            font-style: normal;
-        }
-
-        div.zarr-tree ul,
-        div.zarr-tree li,
-        div.zarr-tree li > div {
-            display: block;
-            position: relative;
-        }
-
-        div.zarr-tree ul,
-        div.zarr-tree li {
-            list-style-type: none;
-        }
-
-        div.zarr-tree li {
-            border-left: 2px solid #000;
-            margin-left: 1em;
-        }
-
-        div.zarr-tree li > div {
-            padding-left: 1.3em;
-            padding-top: 0.225em;
-            padding-bottom: 0.225em;
-        }
-
-        div.zarr-tree li > div::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: -2px;
-            bottom: 50%;
-            width: 1.2em;
-            border-left: 2px solid #000;
-            border-bottom: 2px solid #000;
-        }
-
-        div.zarr-tree > ul > li:first-child > div {
-            padding-left: 4%;
-        }
-
-        div.zarr-tree > ul > li:first-child > div::before {
-            border: 0 none transparent;
-        }
-
-        div.zarr-tree ul > li:last-child {
-            border-left: 2px solid transparent;
-        }
-    """)
-    result += "</style>\n\n"
-
-    # Insert the HTML list
-    result += """<div class="zarr-tree">\n"""
-    result += "<ul>\n"
-    result += custom_html_sublist(group, indent=indent)
-    result += "</ul>\n"
-    result += "</div>\n"
-
-    return result
+tree_group_icon = 'fa fa-folder'
+tree_array_icon = 'fa fa-table'
+# alternatives...
+# tree_group_icon: 'jstree-folder'
+# tree_array_icon: 'jstree-file'
 
 
 class TreeViewer(object):
 
-    def __init__(self, group):
+    def __init__(self, group, expand=False, level=None):
+
         self.group = group
+        self.expand = expand
+        self.level = level
 
         self.text_kwargs = dict(
             horiz_len=2,
@@ -446,11 +457,11 @@ class TreeViewer(object):
 
     def __bytes__(self):
         drawer = LeftAligned(
-            traverse=ZarrGroupTraversal(),
+            traverse=ZarrTraversal(),
             draw=BoxStyle(gfx=self.bytes_kwargs, **self.text_kwargs)
         )
-
-        result = drawer(self.group)
+        root = TreeNode(self.group, level=self.level)
+        result = drawer(root)
 
         # Unicode characters slip in on Python 3.
         # So we need to straighten that out first.
@@ -461,20 +472,20 @@ class TreeViewer(object):
 
     def __unicode__(self):
         drawer = LeftAligned(
-            traverse=ZarrGroupTraversal(),
+            traverse=ZarrTraversal(),
             draw=BoxStyle(gfx=self.unicode_kwargs, **self.text_kwargs)
         )
-
-        return drawer(self.group)
+        root = TreeNode(self.group, level=self.level)
+        return drawer(root)
 
     def __repr__(self):
-        if PY2:
+        if PY2:  # pragma: py3 no cover
             return self.__bytes__()
-        else:
+        else:  # pragma: py2 no cover
             return self.__unicode__()
 
     def _repr_html_(self):
-        return custom_html_list(self.group)
+        return tree_html(self.group, expand=self.expand, level=self.level)
 
 
 def check_array_shape(param, array, shape):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -338,7 +338,7 @@ class TreeNode(object):
         return type(self.obj).__name__
 
 
-class ZarrTraversal(Traversal):
+class TreeTraversal(Traversal):
 
     def get_children(self, node):
         return node.get_children()
@@ -351,13 +351,12 @@ class ZarrTraversal(Traversal):
 
 
 def tree_html_sublist(node, root=False, expand=False):
-    traverser = ZarrTraversal(tree=node)
     result = ''
     data_jstree = '{"type": "%s"}' % node.get_type()
     css_class = 'jstree-open' if (root or expand) else ''
     result += "<li data-jstree='{}' class='{}'>".format(data_jstree, css_class)
-    result += '<span>{}</span>'.format(traverser.get_text(node))
-    children = traverser.get_children(node)
+    result += '<span>{}</span>'.format(node.get_text())
+    children = node.get_children()
     if children:
         result += '<ul>'
         for c in children:
@@ -457,7 +456,7 @@ class TreeViewer(object):
 
     def __bytes__(self):
         drawer = LeftAligned(
-            traverse=ZarrTraversal(),
+            traverse=TreeTraversal(),
             draw=BoxStyle(gfx=self.bytes_kwargs, **self.text_kwargs)
         )
         root = TreeNode(self.group, level=self.level)
@@ -472,7 +471,7 @@ class TreeViewer(object):
 
     def __unicode__(self):
         drawer = LeftAligned(
-            traverse=ZarrTraversal(),
+            traverse=TreeTraversal(),
             draw=BoxStyle(gfx=self.unicode_kwargs, **self.text_kwargs)
         )
         root = TreeNode(self.group, level=self.level)


### PR DESCRIPTION
This PR modifies the tree HTML representation to use jstree. Also adds a "level" parameter to tree() to allow limiting depth to which tree is printed.