### PR TITLE
DBMStore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ branches:
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+    - libdb-dev
+
 python:
   - 2.7
   - 3.4

--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -10,6 +10,7 @@ Storage (``zarr.storage``)
 .. autoclass:: TempStore
 .. autoclass:: NestedDirectoryStore
 .. autoclass:: ZipStore
+.. autoclass:: DBMStore
 
     .. automethod:: close
     .. automethod:: flush

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 appdirs==1.4.3
 args==0.1.0
 asciitree==0.3.3
-bsddb3==6.2.5
 certifi==2017.7.27.1
 chardet==3.0.4
 clint==0.5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 appdirs==1.4.3
 args==0.1.0
 asciitree==0.3.3
+bsddb3==6.2.5
 certifi==2017.7.27.1
 chardet==3.0.4
 clint==0.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,9 @@ commands =
     py36: flake8 --max-line-length=100 zarr
 deps =
     -rrequirements_dev.txt
+    # linux only
+    bsddb3==6.2.5
+
 
 [testenv:docs]
 basepython = python2.7

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import, print_function, division
 from zarr.core import Array
 from zarr.creation import (empty, zeros, ones, full, array, empty_like, zeros_like, ones_like,
                            full_like, open_array, open_like, create)
-from zarr.storage import DictStore, DirectoryStore, ZipStore, TempStore, NestedDirectoryStore
+from zarr.storage import (DictStore, DirectoryStore, ZipStore, TempStore, NestedDirectoryStore,
+                          DBMStore)
 from zarr.hierarchy import group, open_group, Group
 from zarr.sync import ThreadSynchronizer, ProcessSynchronizer
 from zarr.codecs import *

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1131,22 +1131,21 @@ class DBMStore(MutableMapping):
     mode : int
         File mode used if a new file is created.
     open : function, optional
-        Function to open the database file.
+        Function to open the database file. If not provided, `dbm.open` will be used on
+        Python 3, and `anydbm.open` will be used on Python 2.
     **open_kwargs
         Keyword arguments to pass the `open` function.
 
     Notes
     -----
     Please note that, by default, this class will use the Python standard library
-    `dbm.open` function to open the database file. There are up to three different
-    implementations of DBM databases available in any Python installation, and which
-    one is used may vary from one system to another. Database file formats are not
-    compatible between these different implementations. Also some implementations are
-    more efficient than others.
-
-    Most DBM-style database objects already support a MutableMapping interface,
-    but usually accept and return keys as bytes rather than text. This class is just a
-    thin wrapper to map keys from text to bytes and back again.
+    `dbm.open` function to open the database file (or `anydbm.open` on Python 2). There
+    are up to three different implementations of DBM-style databases available in any
+    Python installation, and which one is used may vary from one system to another.
+    Database file formats are not compatible between these different implementations.
+    Also some implementations are more efficient than others. If you want to ensure a
+    specific implementation is used, pass the corresponding open function, e.g.,
+    `dbm.gnu.open` to use the GNU DBM library.
 
     Examples
     --------

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1242,4 +1242,3 @@ class DBMStore(MutableMapping):
     def __contains__(self, key):
         key = encode_key(key)
         return key in self.db
-

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-This module contains storage classes for use with Zarr arrays and groups. Note that any object
-implementing the ``MutableMapping`` interface can be used as a Zarr array store.
+This module contains storage classes for use with Zarr arrays and groups. Note that any
+object implementing the ``MutableMapping`` interface can be used as a Zarr array store.
 
 """
 from __future__ import absolute_import, print_function, division
@@ -138,7 +138,8 @@ def _require_parent_group(path, store, chunk_store, overwrite):
         for i in range(len(segments)):
             p = '/'.join(segments[:i])
             if contains_array(store, p):
-                _init_group_metadata(store, path=p, chunk_store=chunk_store, overwrite=overwrite)
+                _init_group_metadata(store, path=p, chunk_store=chunk_store,
+                                     overwrite=overwrite)
             elif not contains_group(store, p):
                 _init_group_metadata(store, path=p, chunk_store=chunk_store)
 
@@ -348,10 +349,12 @@ def init_group(store, overwrite=False, path=None, chunk_store=None):
     path = normalize_storage_path(path)
 
     # ensure parent group initialized
-    _require_parent_group(path, store=store, chunk_store=chunk_store, overwrite=overwrite)
+    _require_parent_group(path, store=store, chunk_store=chunk_store,
+                          overwrite=overwrite)
 
     # initialise metadata
-    _init_group_metadata(store=store, overwrite=overwrite, path=path, chunk_store=chunk_store)
+    _init_group_metadata(store=store, overwrite=overwrite, path=path,
+                         chunk_store=chunk_store)
 
 
 def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None):
@@ -655,7 +658,8 @@ class DirectoryStore(MutableMapping):
         temp_path = None
         try:
             with tempfile.NamedTemporaryFile(mode='wb', delete=False, dir=dir_path,
-                                             prefix=file_name + '.', suffix='.partial') as f:
+                                             prefix=file_name + '.',
+                                             suffix='.partial') as f:
                 temp_path = f.name
                 f.write(value)
 
@@ -782,9 +786,9 @@ def _map_ckey(key):
 
 
 class NestedDirectoryStore(DirectoryStore):
-    """Mutable Mapping interface to a directory, with special handling for chunk keys so that
-    chunk files for multidimensional arrays are stored in a nested directory tree. Keys must be
-    strings, values must be bytes-like objects.
+    """Mutable Mapping interface to a directory, with special handling for chunk keys so
+    that chunk files for multidimensional arrays are stored in a nested directory tree.
+    Keys must be strings, values must be bytes-like objects.
 
     Parameters
     ----------
@@ -810,8 +814,8 @@ class NestedDirectoryStore(DirectoryStore):
         ...     f.read()
         b'xxx'
 
-    Chunk keys are handled in a special way, such that the '.' characters in the key are mapped to
-    directory path separators internally. E.g.::
+    Chunk keys are handled in a special way, such that the '.' characters in the key
+    are mapped to directory path separators internally. E.g.::
 
         >>> store['bar/0.0'] = b'yyy'
         >>> store['bar/0.0']
@@ -828,11 +832,12 @@ class NestedDirectoryStore(DirectoryStore):
 
     Notes
     -----
-    The standard DirectoryStore class stores all chunk files for an array together in a single
-    directory. On some file systems the potentially large number of files in a single directory
-    can cause performance issues. The NestedDirectoryStore class provides an alternative where
-    chunk files for multidimensional arrays will be organised into a directory hierarchy,
-    thus reducing the number of files in any one directory.
+    The standard DirectoryStore class stores all chunk files for an array together in a
+    single directory. On some file systems the potentially large number of files in a
+    single directory can cause performance issues. The NestedDirectoryStore class
+    provides an alternative where chunk files for multidimensional arrays will be
+    organised into a directory hierarchy, thus reducing the number of files in any one
+    directory.
 
     """
 
@@ -864,8 +869,8 @@ class NestedDirectoryStore(DirectoryStore):
     def listdir(self, path=None):
         children = super(NestedDirectoryStore, self).listdir(path=path)
         if array_meta_key in children:
-            # special handling of directories containing an array to map nested chunk keys back
-            # to standard chunk keys
+            # special handling of directories containing an array to map nested chunk
+            # keys back to standard chunk keys
             new_children = []
             root_path = self.dir_path(path)
             for entry in children:
@@ -941,18 +946,20 @@ class ZipStore(MutableMapping):
         self.mode = mode
 
         # open zip file
-        self.zf = zipfile.ZipFile(path, mode=mode, compression=compression, allowZip64=allowZip64)
+        self.zf = zipfile.ZipFile(path, mode=mode, compression=compression,
+                                  allowZip64=allowZip64)
 
     def __getstate__(self):
         return self.path, self.compression, self.allowZip64, self.mode
 
     def __setstate__(self, state):
         path, compression, allowZip64, mode = state
-        # if initially opened with mode 'w' or 'x', re-open in mode 'a' so file doesn't get
-        # clobbered
+        # if initially opened with mode 'w' or 'x', re-open in mode 'a' so file doesn't
+        # get clobbered
         if mode in 'wx':
             mode = 'a'
-        self.__init__(path=path, compression=compression, allowZip64=allowZip64, mode=mode)
+        self.__init__(path=path, compression=compression, allowZip64=allowZip64,
+                      mode=mode)
 
     def close(self):
         """Closes the underlying zip file, ensuring all records are written."""
@@ -965,8 +972,8 @@ class ZipStore(MutableMapping):
             raise PermissionError('cannot flush read-only ZipStore')
         else:
             self.zf.close()
-            # N.B., re-open with mode 'a' regardless of initial mode so we don't wipe what's been
-            # written
+            # N.B., re-open with mode 'a' regardless of initial mode so we don't wipe
+            # what's been written
             self.zf = zipfile.ZipFile(self.path, mode='a',
                                       compression=self.compression,
                                       allowZip64=self.allowZip64)
@@ -1119,6 +1126,10 @@ class DBMStore(MutableMapping):
     ----------
     path : string
         Location of database file.
+    flag : string, optional
+        Flags for opening the database file.
+    mode : int
+        File mode used if a new file is created.
     open : function, optional
         Function to open the database file.
     **open_kwargs
@@ -1126,15 +1137,16 @@ class DBMStore(MutableMapping):
 
     Notes
     -----
-    Please note that, by default, this class will use the Python standard library `dbm.open`
-    function to open the database file. There are up to three different implementations of DBM
-    databases available in any Python installation, and which one is used may vary from one
-    system to another. Database file formats are not compatible between these different
-    implementations. Also some implementations are more efficient than others.
+    Please note that, by default, this class will use the Python standard library
+    `dbm.open` function to open the database file. There are up to three different
+    implementations of DBM databases available in any Python installation, and which
+    one is used may vary from one system to another. Database file formats are not
+    compatible between these different implementations. Also some implementations are
+    more efficient than others.
 
-    Most DBM-style database objects already support a MutableMapping interface, but usually
-    accept and return keys as bytes rather than text. This class is just a thing wrapper to map
-    keys from text to bytes and back again.
+    Most DBM-style database objects already support a MutableMapping interface,
+    but usually accept and return keys as bytes rather than text. This class is just a
+    thin wrapper to map keys from text to bytes and back again.
 
     Examples
     --------

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 import unittest
-from tempfile import mkdtemp
+from tempfile import mkdtemp, mktemp
 import atexit
 import shutil
 import pickle
+import os
 
 
 import numpy as np
@@ -13,7 +14,7 @@ from nose.tools import (eq_ as eq, assert_is_instance, assert_raises, assert_tru
                         assert_is, assert_is_none)
 
 
-from zarr.storage import DirectoryStore, init_array, init_group, NestedDirectoryStore
+from zarr.storage import DirectoryStore, init_array, init_group, NestedDirectoryStore, DBMStore
 from zarr.core import Array
 from zarr.errors import PermissionError
 from zarr.compat import PY2
@@ -896,6 +897,21 @@ class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
         kwargs.setdefault('compressor', Zlib(1))
         init_array(store, **kwargs)
         return Array(store, read_only=read_only)
+
+
+class TestArrayWithDBMStore(TestArray):
+
+    @staticmethod
+    def create_array(read_only=False, **kwargs):
+        path = mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStore(path, flag='n')
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, **kwargs)
+        return Array(store, read_only=read_only)
+
+    def test_nbytes_stored(self):
+        pass  # not implemented
 
 
 class TestArrayWithNoCompressor(TestArray):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -931,7 +931,7 @@ try:
         def test_nbytes_stored(self):
             pass  # not implemented
 
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -899,7 +899,7 @@ class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
         return Array(store, read_only=read_only)
 
 
-class TestArrayWithDBMStore(TestArray):
+class TestArrayWithDBMStoreStdlib(TestArray):
 
     @staticmethod
     def create_array(read_only=False, **kwargs):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -914,6 +914,27 @@ class TestArrayWithDBMStoreStdlib(TestArray):
         pass  # not implemented
 
 
+try:
+    import bsddb3
+
+    class TestArrayWithDBMStoreBerkeleyDB(TestArray):
+
+        @staticmethod
+        def create_array(read_only=False, **kwargs):
+            path = mktemp(suffix='.dbm')
+            atexit.register(os.remove, path)
+            store = DBMStore(path, flag='n', open=bsddb3.btopen)
+            kwargs.setdefault('compressor', Zlib(1))
+            init_array(store, **kwargs)
+            return Array(store, read_only=read_only)
+
+        def test_nbytes_stored(self):
+            pass  # not implemented
+
+except ImportError:
+    pass
+
+
 class TestArrayWithNoCompressor(TestArray):
 
     def create_array(self, read_only=False, **kwargs):

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -851,7 +851,7 @@ try:
             store = DBMStore(path, flag='n', open=bsddb3.btopen)
             return store, None
 
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -17,7 +17,8 @@ from numpy.testing import assert_array_equal
 
 
 from zarr.storage import (DictStore, DirectoryStore, ZipStore, init_group, init_array, attrs_key,
-                          array_meta_key, group_meta_key, atexit_rmtree, NestedDirectoryStore)
+                          array_meta_key, group_meta_key, atexit_rmtree, NestedDirectoryStore,
+                          DBMStore)
 from zarr.core import Array
 from zarr.compat import PY2, text_type
 from zarr.hierarchy import Group, group, open_group
@@ -825,6 +826,16 @@ class TestGroupWithZipStore(TestGroup):
         path = tempfile.mktemp(suffix='.zip')
         atexit.register(os.remove, path)
         store = ZipStore(path)
+        return store, None
+
+
+class TestGroupWithDBMStore(TestGroup):
+
+    @staticmethod
+    def create_store():
+        path = tempfile.mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStore(path, flag='n')
         return store, None
 
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -839,6 +839,22 @@ class TestGroupWithDBMStoreStdlib(TestGroup):
         return store, None
 
 
+try:
+    import bsddb3
+
+    class TestGroupWithDBMStoreBerkeleyDB(TestGroup):
+
+        @staticmethod
+        def create_store():
+            path = tempfile.mktemp(suffix='.dbm')
+            atexit.register(os.remove, path)
+            store = DBMStore(path, flag='n', open=bsddb3.btopen)
+            return store, None
+
+except ImportError:
+    pass
+
+
 class TestGroupWithChunkStore(TestGroup):
 
     @staticmethod

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -829,7 +829,7 @@ class TestGroupWithZipStore(TestGroup):
         return store, None
 
 
-class TestGroupWithDBMStore(TestGroup):
+class TestGroupWithDBMStoreStdlib(TestGroup):
 
     @staticmethod
     def create_store():

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -669,13 +669,28 @@ class TestZipStore(StoreTests, unittest.TestCase):
             store.flush()
 
 
-class TestDBMStore(StoreTests, unittest.TestCase):
+class TestDBMStoreStdlib(StoreTests, unittest.TestCase):
 
     def create_store(self):
         path = tempfile.mktemp(suffix='.dbm')
         atexit.register(os.remove, path)
         store = DBMStore(path, flag='n')
         return store
+
+
+try:
+    import bsddb3
+
+    class TestDBMStoreBerkeleyDB(StoreTests, unittest.TestCase):
+
+        def create_store(self):
+            path = tempfile.mktemp(suffix='.dbm')
+            atexit.register(os.remove, path)
+            store = DBMStore(path, flag='n', open=bsddb3.btopen)
+            return store
+
+except ImportError:
+    pass
 
 
 def test_getsize():

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -17,7 +17,7 @@ from nose.tools import assert_raises, eq_ as eq, assert_is_none
 
 from zarr.storage import (init_array, array_meta_key, attrs_key, DictStore, DirectoryStore,
                           ZipStore, init_group, group_meta_key, getsize, migrate_1to2, TempStore,
-                          atexit_rmtree, NestedDirectoryStore, default_compressor)
+                          atexit_rmtree, NestedDirectoryStore, default_compressor, DBMStore)
 from zarr.meta import (decode_array_metadata, encode_array_metadata, ZARR_FORMAT,
                        decode_group_metadata, encode_group_metadata)
 from zarr.compat import text_type
@@ -667,6 +667,15 @@ class TestZipStore(StoreTests, unittest.TestCase):
         store = ZipStore('example.zip', mode='r')
         with assert_raises(PermissionError):
             store.flush()
+
+
+class TestDBMStore(StoreTests, unittest.TestCase):
+
+    def create_store(self):
+        path = tempfile.mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStore(path, flag='n')
+        return store
 
 
 def test_getsize():

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -668,6 +668,12 @@ class TestZipStore(StoreTests, unittest.TestCase):
         with assert_raises(PermissionError):
             store.flush()
 
+    def test_context_manager(self):
+        with self.create_store() as store:
+            store['foo'] = b'bar'
+            store['baz'] = b'qux'
+            eq(2, len(store))
+
 
 class TestDBMStoreStdlib(StoreTests, unittest.TestCase):
 
@@ -676,6 +682,12 @@ class TestDBMStoreStdlib(StoreTests, unittest.TestCase):
         atexit.register(os.remove, path)
         store = DBMStore(path, flag='n')
         return store
+
+    def test_context_manager(self):
+        with self.create_store() as store:
+            store['foo'] = b'bar'
+            store['baz'] = b'qux'
+            eq(2, len(store))
 
 
 try:
@@ -689,7 +701,7 @@ try:
             store = DBMStore(path, flag='n', open=bsddb3.btopen)
             return store
 
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 


### PR DESCRIPTION
This PR adds a ``DBMStore`` class, which is a compatibility wrapper around any DBM-style database object, which includes the DBM-style objects available from standard library as well as Berkeley DB and more. Resolves #133.