### PR TITLE
Add Store rename method

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -554,6 +554,15 @@ class DictStore(MutableMapping):
         else:
             return []
 
+    def rename(self, src_path, dst_path):
+        src_path = normalize_storage_path(src_path)
+        dst_path = normalize_storage_path(dst_path)
+
+        src_parent, src_key = self._get_parent(src_path)
+        dst_parent, dst_key = self._require_parent(dst_path)
+
+        dst_parent[dst_key] = src_parent.pop(src_key)
+
     def rmdir(self, path=None):
         path = normalize_storage_path(path)
         if path:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -772,6 +772,20 @@ class DirectoryStore(MutableMapping):
         else:
             return []
 
+    def rename(self, src_path, dst_path):
+        store_src_path = normalize_storage_path(src_path)
+        store_dst_path = normalize_storage_path(dst_path)
+
+        dir_path = self.path
+
+        src_path = os.path.join(dir_path, store_src_path)
+        dst_path = os.path.join(dir_path, store_dst_path)
+
+        dst_dir = os.path.dirname(dst_path)
+        if not os.path.exists(dst_dir):
+            os.makedirs(dst_dir)
+        os.rename(src_path, dst_path)
+
     def rmdir(self, path=None):
         store_path = normalize_storage_path(path)
         dir_path = self.path

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -85,6 +85,28 @@ def rmdir(store, path=None):
         _rmdir_from_keys(store, path)
 
 
+def _rename_from_keys(store, src_path, dst_path):
+    # assume path already normalized
+    src_prefix = _path_to_prefix(src_path)
+    dst_prefix = _path_to_prefix(dst_path)
+    for key in list(store.keys()):
+        if key.startswith(src_prefix):
+            new_key = dst_prefix + key.lstrip(src_prefix)
+            store[new_key] = store.pop(key)
+
+
+def rename(store, src_path, dst_path):
+    """Rename all items under the given path."""
+    src_path = normalize_storage_path(src_path)
+    dst_path = normalize_storage_path(dst_path)
+    if hasattr(store, 'rename'):
+        # pass through
+        store.rename(src_path, dst_path)
+    else:
+        # slow version, delete one key at a time
+        _rename_from_keys(store, src_path, dst_path)
+
+
 def _listdir_from_keys(store, path=None):
     # assume path already normalized
     prefix = _path_to_prefix(path)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -195,6 +195,52 @@ class StoreTests(object):
             eq([], store.listdir('c/d/y/z'))
             eq([], store.listdir('c/e/f'))
 
+        # test rename (optional)
+        if hasattr(store, 'rename'):
+            store.rename('c/e', 'c/e2')
+            assert 'c/d' in store
+            assert 'c/e' not in store
+            assert 'c/e/f' not in store
+            assert 'c/e/g' not in store
+            assert 'c/e2' not in store
+            assert 'c/e2/f' in store
+            assert 'c/e2/g' in store
+            store.rename('c/e2', 'c/e')
+            assert 'c/d' in store
+            assert 'c/e2' not in store
+            assert 'c/e2/f' not in store
+            assert 'c/e2/g' not in store
+            assert 'c/e' not in store
+            assert 'c/e/f' in store
+            assert 'c/e/g' in store
+            store.rename('c', 'c1/c2/c3')
+            assert 'a' in store
+            assert 'c' not in store
+            assert 'c/d' not in store
+            assert 'c/e' not in store
+            assert 'c/e/f' not in store
+            assert 'c/e/g' not in store
+            assert 'c1' not in store
+            assert 'c1/c2' not in store
+            assert 'c1/c2/c3' not in store
+            assert 'c1/c2/c3/d' in store
+            assert 'c1/c2/c3/e' not in store
+            assert 'c1/c2/c3/e/f' in store
+            assert 'c1/c2/c3/e/g' in store
+            store.rename('c1/c2/c3', 'c')
+            assert 'c' not in store
+            assert 'c/d' in store
+            assert 'c/e' not in store
+            assert 'c/e/f' in store
+            assert 'c/e/g' in store
+            assert 'c1' not in store
+            assert 'c1/c2' not in store
+            assert 'c1/c2/c3' not in store
+            assert 'c1/c2/c3/d' not in store
+            assert 'c1/c2/c3/e' not in store
+            assert 'c1/c2/c3/e/f' not in store
+            assert 'c1/c2/c3/e/g' not in store
+
         # test rmdir (optional)
         if hasattr(store, 'rmdir'):
             store.rmdir('c/e')


### PR DESCRIPTION
Lays the ground work for resolving issue ( https://github.com/alimanfoo/zarr/issues/191 ). Namely adds a `rename` function on some `Store`s like `Dict` and `DirectoryStore`. This can later be used by `move`. Since this requires a deletion step it won't work for things like `ZipStore`.