### PR TITLE
Add move

### DIFF
--- a/docs/api/hierarchy.rst
+++ b/docs/api/hierarchy.rst
@@ -36,3 +36,4 @@ Groups (``zarr.hierarchy``)
     .. automethod:: zeros_like
     .. automethod:: ones_like
     .. automethod:: full_like
+    .. automethod:: move

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -689,6 +689,9 @@ class TestGroup(unittest.TestCase):
         g = self.create_group()
 
         data = np.arange(100)
+        g['boo'] = data
+
+        data = np.arange(100)
         g['foo'] = data
 
         try:
@@ -719,6 +722,12 @@ class TestGroup(unittest.TestCase):
             assert 'bar' in g
             assert isinstance(g['foo2'], Group)
             assert_array_equal(data, g['bar'])
+
+            with assert_raises(ValueError):
+                g2.move('bar', 'bar2')
+
+            with assert_raises(ValueError):
+                g.move('bar', 'boo')
         except NotImplementedError:
             pass
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -685,6 +685,43 @@ class TestGroup(unittest.TestCase):
             assert 'bar' not in g
             assert 'bar/baz' not in g
 
+    def test_move(self):
+        g = self.create_group()
+
+        data = np.arange(100)
+        g['foo'] = data
+
+        try:
+            g.move('foo', 'bar')
+            assert 'foo' not in g
+            assert 'bar' in g
+            assert_array_equal(data, g['bar'])
+
+            g.move('bar', 'foo/bar')
+            assert 'bar' not in g
+            assert 'foo' in g
+            assert 'foo/bar' in g
+            assert isinstance(g['foo'], Group)
+            assert_array_equal(data, g['foo/bar'])
+
+            g.move('foo', 'foo2')
+            assert 'foo' not in g
+            assert 'foo/bar' not in g
+            assert 'foo2' in g
+            assert 'foo2/bar' in g
+            assert isinstance(g['foo2'], Group)
+            assert_array_equal(data, g['foo2/bar'])
+
+            g2 = g['foo2']
+            g2.move('bar', '/bar')
+            assert 'foo2' in g
+            assert 'foo2/bar' not in g
+            assert 'bar' in g
+            assert isinstance(g['foo2'], Group)
+            assert_array_equal(data, g['bar'])
+        except NotImplementedError:
+            pass
+
     def test_array_creation(self):
         grp = self.create_group()
 


### PR DESCRIPTION
Fixes https://github.com/alimanfoo/zarr/issues/191

Provides a `move` method for Zarr `Group`s akin to the `move` method for h5py's `Group`s. Also adds a `rename` function for Zarr `Store`s, which is used to carry out the `move` operation. The `move` operation will also create any missing `Group`s in the process just in `h5py`. Since this requires a deletion step, it won't work for things like `ZipStore`.