### PR TITLE
Object dtype convenience API; datetime64/timedelta64 support

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,10 +1,15 @@
 Release notes
 =============
 
-.. release_2.2.0rc1
+.. _release_2.2.0rc1:
 
 2.2.0rc1
 --------
+
+To install the release candidate version::
+
+    $ pip install --pre zarr==2.2.0rc1
+
 
 Enhancements
 ~~~~~~~~~~~~
@@ -119,6 +124,9 @@ Enhancements
   continue to work, however a warning will be raised to encourage use of the
   ``object_codec`` parameter. :issue:`208`, :issue:`212`.
 
+* **Added support for ``datetime64`` and ``timedelta64`` data types**;
+  :issue:`85`, :issue:`215`.
+
 Bug fixes
 ~~~~~~~~~
 
@@ -146,14 +154,8 @@ Documentation
 * Some changes have been made to the :ref:`spec_v2` document to clarify
   ambiguities and add some missing information. These changes do not break compatibility
   with any of the material as previously implemented, and so the changes have been made
-  in-place in the document without incrementing the document version number. The
-  specification now describes how bytes fill values should be encoded and
-  decoded for arrays with a fixed-length byte string data type (:issue:`165`,
-  :issue:`176`). The specification now clarifies that datetime64 and
-  timedelta64 data types are not supported in this version (:issue:`85`). The
-  specification now clarifies that the '.zattrs' key does not have to be present for
-  either arrays or groups, and if absent then custom attributes should be treated as
-  empty.
+  in-place in the document without incrementing the document version number. See the
+  section on :ref:`spec_v2_changes` in the specification document for more information.
 * A new :ref:`tutorial_indexing` section has been added to the tutorial.
 * A new :ref:`tutorial_strings` section has been added to the tutorial
   (:issue:`135`, :issue:`175`).

--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -117,17 +117,20 @@ consists of 3 parts:
   ``">"``: big-endian; ``"|"``: not-relevant)
 * One character code giving the basic type of the array (``"b"``: Boolean (integer
   type where all values are only True or False); ``"i"``: integer; ``"u"``: unsigned
-  integer; ``"f"``: floating point; ``"c"``: complex floating point; ``"S"``: string
-  (fixed-length sequence of char); ``"U"``: unicode (fixed-length sequence of
-  Py_UNICODE); ``"V"``: other (void * – each item is a fixed-size chunk of memory))
+  integer; ``"f"``: floating point; ``"c"``: complex floating point; ``"m"``: timedelta;
+  ``"M"``: datetime; ``"S"``: string (fixed-length sequence of char); ``"U"``: unicode
+  (fixed-length sequence of Py_UNICODE); ``"V"``: other (void * – each item is a
+  fixed-size chunk of memory))
 * An integer specifying the number of bytes the type uses.
 
 The byte order MUST be specified. E.g., ``"<f8"``, ``">i4"``, ``"|b1"`` and
 ``"|S12"`` are valid data type encodings.
 
-Please note that NumPy's datetime64 ("M") and timedelta64 ("m") data types are **not**
-currently supported. Please store data using an appropriate physical data type instead,
-e.g., 64-bit integer.
+For datetime64 ("M") and timedelta64 ("m") data types, these MUST also include the
+units within square brackets. A list of valid units and their definitions are given in
+the `NumPy documentation on Datetimes and Timedeltas
+<https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html#datetime-units>`_.
+For example, ``"<M8[ns]"`` specifies a datetime64 data type with nanosecond time units.
 
 Structured data types (i.e., with multiple named fields) are encoded as a list
 of two-element lists, following `NumPy array protocol type descriptions (descr)
@@ -476,8 +479,8 @@ initially published to clarify ambiguities and add some missing information.
   decoded for arrays with a fixed-length byte string data type (:issue:`165`,
   :issue:`176`).
 
-* The specification now clarifies that datetime64 and timedelta64 data types are not
-  supported in this version (:issue:`85`).
+* The specification now clarifies that units must be specified for datetime64 and
+  timedelta64 data types (:issue:`85`, :issue:`215`).
 
 * The specification now clarifies that the '.zattrs' key does not have to be present for
   either arrays or groups, and if absent then custom attributes should be treated as

--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -15,6 +15,8 @@ Status
 This specification is the latest version. See :ref:`spec` for previous
 versions.
 
+.. _spec_v2_storage:
+
 Storage
 -------
 
@@ -32,8 +34,12 @@ resources can be read, written or deleted via HTTP.
 
 Below an "array store" refers to any system implementing this interface.
 
+.. _spec_v2_array:
+
 Arrays
 ------
+
+.. _spec_v2_array_metadata:
 
 Metadata
 ~~~~~~~~
@@ -105,6 +111,8 @@ using the Blosc compression library prior to storage::
         "zarr_format": 2
     }
 
+.. _spec_v2_array_dtype:
+
 Data type encoding
 ~~~~~~~~~~~~~~~~~~
 
@@ -139,6 +147,8 @@ example, the JSON list ``[["r", "|u1"], ["g", "|u1"], ["b", "|u1"]]`` defines a
 data type composed of three single-byte unsigned integers labelled "r", "g" and
 "b".
 
+.. _spec_v2_array_fill_value:
+
 Fill value encoding
 ~~~~~~~~~~~~~~~~~~~
 
@@ -156,6 +166,8 @@ Negative Infinity  ``"-Infinity"``
 If an array has a fixed length byte string data type (e.g., ``"|S12"``), or a
 structured data type, and if the fill value is not null, then the fill value
 MUST be encoded as an ASCII string using the standard Base64 alphabet.
+
+.. _spec_v2_array_chunks:
 
 Chunks
 ~~~~~~
@@ -190,6 +202,8 @@ array dimension is not exactly divisible by the length of the corresponding
 chunk dimension then some chunks will overhang the edge of the array. The
 contents of any chunk region falling outside the array are undefined.
 
+.. _spec_v2_array_filters:
+
 Filters
 ~~~~~~~
 
@@ -200,8 +214,12 @@ the primary compressor. When retrieving data, stored chunk data are
 decompressed by the primary compressor then decoded using filters in the
 reverse order.
 
+.. _spec_v2_hierarchy:
+
 Hierarchies
 -----------
+
+.. _spec_v2_hierarchy_paths:
 
 Logical storage paths
 ~~~~~~~~~~~~~~~~~~~~~
@@ -238,6 +256,8 @@ treat all keys as opaque ASCII strings; equally, an array store could map
 logical paths onto some kind of hierarchical storage (e.g., directories on a
 file system).
 
+.. _spec_v2_hierarchy_groups:
+
 Groups
 ~~~~~~
 
@@ -272,6 +292,8 @@ under the logical paths "foo" and "foo/bar" and an array exists at logical path
 "foo/baz" then the members of the group at path "foo" are the group at path
 "foo/bar" and the array at path "foo/baz".
 
+.. _spec_v2_attrs:
+
 Attributes
 ----------
 
@@ -289,6 +311,8 @@ For example, the JSON object below encodes three attributes named
         "bar": "apples",
         "baz": [1, 2, 3, 4]
     }
+
+.. _spec_v2_examples:
 
 Examples
 --------
@@ -466,6 +490,8 @@ What has been stored::
     foo/bar/1.0
     foo/bar/1.1
 
+.. _spec_v2_changes:
+
 Changes
 -------
 
@@ -487,8 +513,8 @@ initially published to clarify ambiguities and add some missing information.
   empty.
 
 
-Changes in version 2
-~~~~~~~~~~~~~~~~~~~~
+Changes from version 1 to version 2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following changes were made between version 1 and version 2 of this specification:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1079,10 +1079,10 @@ E.g., pickle/unpickle an array stored on disk::
 Datetimes and timedeltas
 ------------------------
 
-NumPy's ``datetime64`` ('M') and ``timedelta64`` ('m') dtypes are supported for Zarr
+NumPy's ``datetime64`` ('M8') and ``timedelta64`` ('m8') dtypes are supported for Zarr
 arrays, as long as the units are specified. E.g.::
 
-    >>> z = zarr.array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='M[D]')
+    >>> z = zarr.array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='M8[D]')
     >>> z
     <zarr.core.Array (3,) datetime64[D]>
     >>> z[:]

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1079,24 +1079,13 @@ E.g., pickle/unpickle an array stored on disk::
 Datetimes and timedeltas
 ------------------------
 
-Please note that NumPy's ``datetime64`` and ``timedelta64`` dtypes are **not** currently
-supported for Zarr arrays. If you would like to store datetime or timedelta data, you
-can store the data in an array with an integer dtype, e.g.::
+NumPy's ``datetime64`` ('M') and ``timedelta64`` ('m') dtypes are supported for Zarr
+arrays, as long as the units are specified. E.g.::
 
-    >>> a = np.array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='datetime64[D]')
-    >>> z = zarr.array(a.view('i8'))
+    >>> z = zarr.array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='M[D]')
     >>> z
-    <zarr.core.Array (3,) int64>
+    <zarr.core.Array (3,) datetime64[D]>
     >>> z[:]
-    array([13707, 13161, 14834])
-    >>> z[:].view(a.dtype)
-    array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='datetime64[D]')
-
-If you would like a convenient way to retrieve the data from this array viewed as the
-original datetime64 dtype, try the :func:`zarr.core.Array.astype` method, e.g.::
-
-    >>> zv = z.astype(a.dtype)
-    >>> zv[:]
     array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='datetime64[D]')
 
 .. _tutorial_tips:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -779,6 +779,8 @@ If your strings are all ASCII strings, and you know the maximum length of the st
 your dataset, then you can use an array with a fixed-length bytes dtype. E.g.::
 
     >>> z = zarr.zeros(10, dtype='S6')
+    >>> z
+    <zarr.core.Array (10,) |S6>
     >>> z[0] = b'Hello'
     >>> z[1] = b'world!'
     >>> z[:]
@@ -793,37 +795,68 @@ A fixed-length unicode dtype is also available, e.g.::
     ...              'เฮลโลเวิลด์']
     >>> text_data = greetings * 10000
     >>> z = zarr.array(text_data, dtype='U20')
+    >>> z
+    <zarr.core.Array (120000,) <U20>
     >>> z[:]
     array(['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', ...,
            'Helló, világ!', 'Zdravo svete!', 'เฮลโลเวิลด์'],
           dtype='<U20')
 
-For variable-length strings, the "object" dtype can be used, but a codec must be
+For variable-length strings, the ``object`` dtype can be used, but a codec must be
 provided to encode the data (see also :ref:`tutorial_objects` below). At the time of
-writing there are three codecs available that can encode variable length string
-objects, :class:`numcodecs.JSON`, :class:`numcodecs.MsgPack`. and
-:class:`numcodecs.Pickle`. E.g. using JSON::
+writing there are four codecs available that can encode variable length string
+objects: :class:`numcodecs.VLenUTF8`, :class:`numcodecs.JSON`, :class:`numcodecs.MsgPack`.
+and :class:`numcodecs.Pickle`. E.g. using ``VLenUTF8``::
 
     >>> import numcodecs
-    >>> z = zarr.array(text_data, dtype=object, object_codec=numcodecs.JSON())
+    >>> z = zarr.array(text_data, dtype=object, object_codec=numcodecs.VLenUTF8())
+    >>> z
+    <zarr.core.Array (120000,) object>
+    >>> z.filters
+    [VLenUTF8()]
     >>> z[:]
     array(['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', ...,
            'Helló, világ!', 'Zdravo svete!', 'เฮลโลเวิลด์'], dtype=object)
 
-...or alternatively using msgpack (requires `msgpack-python
-<https://github.com/msgpack/msgpack-python>`_ to be installed)::
+As a convenience, ``dtype=str`` (or ``dtype=unicode`` on Python 2.7) can be used, which
+is a short-hand for ``dtype=object, object_codec=numcodecs.VLenUTF8()``, e.g.::
 
-    >>> z = zarr.array(text_data, dtype=object, object_codec=numcodecs.MsgPack())
+    >>> z = zarr.array(text_data, dtype=str)
+    >>> z
+    <zarr.core.Array (120000,) object>
+    >>> z.filters
+    [VLenUTF8()]
     >>> z[:]
     array(['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', ...,
            'Helló, világ!', 'Zdravo svete!', 'เฮลโลเวิลด์'], dtype=object)
 
-If you know ahead of time all the possible string values that can occur, then you could
-also use the :class:`numcodecs.Categorize` codec to encode each unique value as an
+Variable-length byte strings are also supported via ``dtype=object``. Again an
+``object_codec`` is required, which can be one of :class:`numcodecs.VLenBytes` or
+:class:`numcodecs.Pickle`. For convenience, ``dtype=bytes`` (or ``dtype=str`` on Python
+2.7) can be used as a short-hand for ``dtype=object, object_codec=numcodecs.VLenBytes()``,
+e.g.::
+
+    >>> bytes_data = [g.encode('utf-8') for g in greetings] * 10000
+    >>> z = zarr.array(bytes_data, dtype=bytes)
+    >>> z
+    <zarr.core.Array (120000,) object>
+    >>> z.filters
+    [VLenBytes()]
+    >>> z[:]
+    array([b'\xc2\xa1Hola mundo!', b'Hej V\xc3\xa4rlden!', b'Servus Woid!',
+           ..., b'Hell\xc3\xb3, vil\xc3\xa1g!', b'Zdravo svete!',
+           b'\xe0\xb9\x80\xe0\xb8\xae\xe0\xb8\xa5\xe0\xb9\x82\xe0\xb8\xa5\xe0\xb9\x80\xe0\xb8\xa7\xe0\xb8\xb4\xe0\xb8\xa5\xe0\xb8\x94\xe0\xb9\x8c'], dtype=object)
+
+If you know ahead of time all the possible string values that can occur, you could
+also use the :class:`numcodecs.Categorize` codec to encode each unique string value as an
 integer. E.g.::
 
     >>> categorize = numcodecs.Categorize(greetings, dtype=object)
     >>> z = zarr.array(text_data, dtype=object, object_codec=categorize)
+    >>> z
+    <zarr.core.Array (120000,) object>
+    >>> z.filters
+    [Categorize(dtype='|O', astype='|u1', labels=['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', ...])]
     >>> z[:]
     array(['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', ...,
            'Helló, világ!', 'Zdravo svete!', 'เฮลโลเวิลด์'], dtype=object)
@@ -835,13 +868,14 @@ Object arrays
 -------------
 
 Zarr supports arrays with an "object" dtype. This allows arrays to contain any type of
-object, such as variable length unicode strings, or variable length lists, or other
-possibilities. When creating an object array, a codec must be provided via the
+object, such as variable length unicode strings, or variable length arrays of numbers, or
+other possibilities. When creating an object array, a codec must be provided via the
 ``object_codec`` argument. This codec handles encoding (serialization) of Python objects.
-At the time of writing there are three codecs available that can serve as a
-general purpose object codec and support encoding of a variety of
-object types: :class:`numcodecs.JSON`, :class:`numcodecs.MsgPack`. and
-:class:`numcodecs.Pickle`.
+The best codec to use will depend on what type of objects are present in the array.
+
+At the time of writing there are three codecs available that can serve as a general
+purpose object codec and support encoding of a mixture of object types:
+:class:`numcodecs.JSON`, :class:`numcodecs.MsgPack`. and :class:`numcodecs.Pickle`.
 
 For example, using the JSON codec::
 
@@ -861,6 +895,40 @@ code can be embedded within pickled data. The JSON and MsgPack codecs do not hav
 security issues and support encoding of unicode strings, lists and dictionaries.
 MsgPack is usually faster for both encoding and decoding.
 
+Ragged arrays
+~~~~~~~~~~~~~
+
+If you need to store an array of arrays, where each member array can be of any length
+and stores the same primitive type (a.k.a. a ragged array), the
+:class:`numcodecs.VLenArray` codec can be used, e.g.::
+
+    >>> z = zarr.empty(4, dtype=object, object_codec=numcodecs.VLenArray(int))
+    >>> z
+    <zarr.core.Array (4,) object>
+    >>> z.filters
+    [VLenArray(dtype='<i8')]
+    >>> z[0] = np.array([1, 3, 5])
+    >>> z[1] = np.array([4])
+    >>> z[2] = np.array([7, 9, 14])
+    >>> z[:]
+    array([array([1, 3, 5]), array([4]), array([ 7,  9, 14]),
+           array([], dtype=int64)], dtype=object)
+
+As a convenience, ``dtype='array:T'`` can be used as a short-hand for
+``dtype=object, object_codec=numcodecs.VLenArray('T')``, where 'T' can be any NumPy
+primitive dtype such as 'i4' or 'f8'. E.g.::
+
+    >>> z = zarr.empty(4, dtype='array:i8')
+    >>> z
+    <zarr.core.Array (4,) object>
+    >>> z.filters
+    [VLenArray(dtype='<i8')]
+    >>> z[0] = np.array([1, 3, 5])
+    >>> z[1] = np.array([4])
+    >>> z[2] = np.array([7, 9, 14])
+    >>> z[:]
+    array([array([1, 3, 5]), array([4]), array([ 7,  9, 14]),
+           array([], dtype=int64)], dtype=object)
 
 .. _tutorial_chunks:
 
@@ -1087,6 +1155,11 @@ arrays, as long as the units are specified. E.g.::
     <zarr.core.Array (3,) datetime64[D]>
     >>> z[:]
     array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='datetime64[D]')
+    >>> z[0]
+    numpy.datetime64('2007-07-13')
+    >>> z[0] = '1999-12-31'
+    >>> z[:]
+    array(['1999-12-31', '2006-01-13', '2010-08-13'], dtype='datetime64[D]')
 
 .. _tutorial_tips:
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,7 @@ mccabe==0.6.1
 monotonic==1.3
 msgpack-python==0.4.8
 nose==1.3.7
-numcodecs==0.4.1
+numcodecs==0.5.0
 numpy==1.13.3
 packaging==16.8
 pkginfo==1.4.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,7 @@ mccabe==0.6.1
 monotonic==1.3
 msgpack-python==0.4.8
 nose==1.3.7
-numcodecs==0.5.0
+numcodecs==0.5.1
 numpy==1.13.3
 packaging==16.8
 pkginfo==1.4.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,7 @@ mccabe==0.6.1
 monotonic==1.3
 msgpack-python==0.4.8
 nose==1.3.7
-numcodecs==0.5.1
+numcodecs==0.5.2
 numpy==1.13.3
 packaging==16.8
 pkginfo==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'asciitree',
         'numpy>=1.7',
         'fasteners',
-        'numcodecs>=0.5.1',
+        'numcodecs>=0.5.2',
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'asciitree',
         'numpy>=1.7',
         'fasteners',
-        'numcodecs>=0.4.1',
+        'numcodecs>=0.5.0',
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'asciitree',
         'numpy>=1.7',
         'fasteners',
-        'numcodecs>=0.5.0',
+        'numcodecs>=0.5.1',
     ],
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -178,5 +178,7 @@ def encode_fill_value(v, dtype):
         return v
     elif dtype.kind == 'U':
         return v
+    elif dtype.kind in 'mM':
+        return int(v.view('u8'))
     else:
         return v

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -25,7 +25,8 @@ import numpy as np
 
 
 from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
-                       normalize_storage_path, buffer_size, normalize_fill_value, nolock)
+                       normalize_storage_path, buffer_size,
+                       normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
 from zarr.compat import PY2, binary_type
 from numcodecs.registry import codec_registry
@@ -308,10 +309,7 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
 
     # normalize metadata
     shape = normalize_shape(shape)
-    dtype = np.dtype(dtype)
-    if dtype.kind in 'mM':
-        raise ValueError('datetime64 and timedelta64 dtypes are not currently supported; '
-                         'please store the data using int64 instead')
+    dtype, object_codec = normalize_dtype(dtype, object_codec)
     chunks = normalize_chunks(chunks, shape, dtype.itemsize)
     order = normalize_order(order)
     fill_value = normalize_fill_value(fill_value, dtype)

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1027,24 +1027,11 @@ class TestArray(unittest.TestCase):
             z[:] = 42
 
         # do something else dangerous
-        labels = [
-            '¡Hola mundo!',
-            'Hej Världen!',
-            'Servus Woid!',
-            'Hei maailma!',
-            'Xin chào thế giới',
-            'Njatjeta Botë!',
-            'Γεια σου κόσμε!',
-            'こんにちは世界',
-            '世界，你好！',
-            'Helló, világ!',
-            'Zdravo svete!',
-            'เฮลโลเวิลด์'
-        ]
-        data = labels * 10
+        data = greetings * 10
         for compressor in Zlib(1), Blosc():
             z = self.create_array(shape=len(data), chunks=30, dtype=object,
-                                  object_codec=Categorize(labels, dtype=object),
+                                  object_codec=Categorize(greetings,
+                                                          dtype=object),
                                   compressor=compressor)
             z[:] = data
             v = z.view(filters=[])

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -855,27 +855,37 @@ class TestArray(unittest.TestCase):
     def test_dtypes(self):
 
         # integers
-        for t in 'u1', 'u2', 'u4', 'u8', 'i1', 'i2', 'i4', 'i8':
-            z = self.create_array(shape=10, chunks=3, dtype=t)
-            assert z.dtype == np.dtype(t)
-            a = np.arange(z.shape[0], dtype=t)
+        for dtype in 'u1', 'u2', 'u4', 'u8', 'i1', 'i2', 'i4', 'i8':
+            z = self.create_array(shape=10, chunks=3, dtype=dtype)
+            assert z.dtype == np.dtype(dtype)
+            a = np.arange(z.shape[0], dtype=dtype)
             z[:] = a
             assert_array_equal(a, z[:])
 
         # floats
-        for t in 'f2', 'f4', 'f8':
-            z = self.create_array(shape=10, chunks=3, dtype=t)
-            assert z.dtype == np.dtype(t)
-            a = np.linspace(0, 1, z.shape[0], dtype=t)
+        for dtype in 'f2', 'f4', 'f8':
+            z = self.create_array(shape=10, chunks=3, dtype=dtype)
+            assert z.dtype == np.dtype(dtype)
+            a = np.linspace(0, 1, z.shape[0], dtype=dtype)
             z[:] = a
             assert_array_almost_equal(a, z[:])
 
-        # datetime, timedelta are not supported for the time being
-        for resolution in 'D', 'us', 'ns':
-            with assert_raises(ValueError):
-                self.create_array(shape=10, dtype='datetime64[{}]'.format(resolution))
-            with assert_raises(ValueError):
-                self.create_array(shape=10, dtype='timedelta64[{}]'.format(resolution))
+        # datetime, timedelta
+        for base_type in 'Mm':
+            for resolution in 'D', 'us', 'ns':
+                dtype = '{}8[{}]'.format(base_type, resolution)
+                z = self.create_array(shape=100, dtype=dtype)
+                assert z.dtype == np.dtype(dtype)
+                a = np.random.randint(0, np.iinfo('u8').max, size=z.shape[0],
+                                      dtype='u8').view(dtype)
+                z[:] = a
+                assert_array_equal(a, z[:])
+
+        # check that datetime generic units are not allowed
+        with assert_raises(ValueError):
+            self.create_array(shape=100, dtype='M8')
+        with assert_raises(ValueError):
+            self.create_array(shape=100, dtype='m8')
 
     def test_object_arrays(self):
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -874,7 +874,7 @@ class TestArray(unittest.TestCase):
         for base_type in 'Mm':
             for resolution in 'D', 'us', 'ns':
                 dtype = '{}8[{}]'.format(base_type, resolution)
-                z = self.create_array(shape=100, dtype=dtype)
+                z = self.create_array(shape=100, dtype=dtype, fill_value=0)
                 assert z.dtype == np.dtype(dtype)
                 a = np.random.randint(0, np.iinfo('u8').max, size=z.shape[0],
                                       dtype='u8').view(dtype)

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -948,8 +948,16 @@ class TestArray(unittest.TestCase):
         data = np.array(greetings * 1000, dtype=object)
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=VLenUTF8())
+        z[0] = u'foo'
+        assert z[0] == u'foo'
+        z[1] = u'bar'
+        assert z[1] == u'bar'
+        z[2] = u'baz'
+        assert z[2] == u'baz'
         z[:] = data
-        assert_array_equal(data, z[:])
+        a = z[:]
+        assert a.dtype == object
+        assert_array_equal(data, a)
 
         # convenience API
         z = self.create_array(shape=data.shape, dtype=text_type)
@@ -981,8 +989,16 @@ class TestArray(unittest.TestCase):
         data = np.array(greetings_bytes * 1000, dtype=object)
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=VLenBytes())
+        z[0] = b'foo'
+        assert z[0] == b'foo'
+        z[1] = b'bar'
+        assert z[1] == b'bar'
+        z[2] = b'baz'
+        assert z[2] == b'baz'
         z[:] = data
-        assert_array_equal(data, z[:])
+        a = z[:]
+        assert a.dtype == object
+        assert_array_equal(data, a)
 
         # convenience API
         z = self.create_array(shape=data.shape, dtype=binary_type)
@@ -1013,8 +1029,12 @@ class TestArray(unittest.TestCase):
         codecs = VLenArray(int), VLenArray('<u4')
         for codec in codecs:
             z = self.create_array(shape=data.shape, dtype=object, object_codec=codec)
+            z[0] = np.array([4, 7])
+            assert_array_equal(np.array([4, 7]), z[0])
             z[:] = data
-            compare_arrays(data, z[:], codec.dtype)
+            a = z[:]
+            assert a.dtype == object
+            compare_arrays(data, a, codec.dtype)
 
         # convenience API
         for item_type in 'int', '<u4':

--- a/zarr/tests/test_filters.py
+++ b/zarr/tests/test_filters.py
@@ -169,8 +169,8 @@ def test_array_with_packbits_filter():
 def test_array_with_categorize_filter():
 
     # setup
-    data = np.random.choice([b'foo', b'bar', b'baz'], size=100)
-    flt = Categorize(dtype=data.dtype, labels=['foo', 'bar', 'baz'])
+    data = np.random.choice([u'foo', u'bar', u'baz'], size=100)
+    flt = Categorize(dtype=data.dtype, labels=[u'foo', u'bar', u'baz'])
     filters = [flt]
 
     for compressor in compressors:

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -145,7 +145,7 @@ def normalize_dtype(dtype, object_codec):
                     args = ()
                 try:
                     object_codec = codec_registry[codec_id](*args)
-                except KeyError:
+                except KeyError:  # pragma: no cover
                     raise ValueError('codec %r for object type %r is not '
                                      'available; please provide an '
                                      'object_codec manually' % (codec_id, key))

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -153,9 +153,10 @@ def normalize_dtype(dtype, object_codec):
 
     dtype = np.dtype(dtype)
 
-    if dtype.kind in 'mM':
-        raise ValueError('datetime64 and timedelta64 dtypes are not currently '
-                         'supported; please store the data using int64 instead')
+    # don't allow generic datetime64 or timedelta64, require units to be specified
+    if dtype == np.dtype('M8') or dtype == np.dtype('m8'):
+        raise ValueError('datetime64 and timedelta64 dtypes with generic units '
+                         'are not supported, please specify units (e.g., "M8[ns]")')
 
     return dtype, object_codec
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -132,6 +132,7 @@ def normalize_dtype(dtype, object_codec):
     if inspect.isclass(dtype):
         dtype = dtype.__name__
     if isinstance(dtype, str):
+        # allow ':' to delimit class from codec arguments
         tokens = dtype.split(':')
         key = tokens[0]
         if key in object_codecs:


### PR DESCRIPTION
Numcodecs 0.5.0 adds some new codecs for variable length text (unicode) strings ([VLenUTF8](http://numcodecs.readthedocs.io/en/stable/vlen.html#numcodecs.vlen.VLenUTF8)), variable length byte strings ([VLenBytes](http://numcodecs.readthedocs.io/en/stable/vlen.html#numcodecs.vlen.VLenBytes)) and variable length arrays of primitive numpy types ([VLenArray](http://numcodecs.readthedocs.io/en/stable/vlen.html#numcodecs.vlen.VLenArray)). These codecs all use the [Parquet format byte array encoding](https://github.com/apache/parquet-format/blob/master/Encodings.md#plain-plain--0). The codecs have [good performance and encoded data size](https://github.com/alimanfoo/numcodecs/blob/master/notebooks/benchmark_vlen.ipynb) and provide a platform-independent encoding for these common cases.

This PR leverages these new codecs to propose a convenience API for Zarr object arrays.

## ``dtype=str``

If ``dtype=str`` (or ``dtype=unicode`` on PY2) is provided, this is treated as a short-hand for an array with ``dtype=object`` and ``object_codec=numcodecs.VLenUTF8()``. E.g.:

```python
In [1]: import zarr

In [2]: from numcodecs.tests.common import greetings

In [3]: z = zarr.array(greetings, dtype=str)

In [4]: z[:]
Out[4]: 
array(['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', 'Hei maailma!',
       'Xin chào thế giới', 'Njatjeta Botë!', 'Γεια σου κόσμε!', 'こんにちは世界',
       '世界，你好！', 'Helló, világ!', 'Zdravo svete!', 'เฮลโลเวิลด์'], dtype=object)

In [5]: z
Out[5]: <zarr.core.Array (12,) object>

In [6]: z.filters
Out[6]: [VLenUTF8()]
``` 

## ``dtype=bytes``

If ``dtype=bytes`` (or ``dtype=str`` on PY2) is provided, this is treated as a short-hand for an array with ``dtype=object`` and ``object_codec=numcodecs.VLenBytes()``. E.g.:

```python
In [8]: z = zarr.array(greetings_bytes, dtype=bytes)

In [9]: z[:]
Out[9]: 
array([b'\xc2\xa1Hola mundo!', b'Hej V\xc3\xa4rlden!', b'Servus Woid!',
       b'Hei maailma!', b'Xin ch\xc3\xa0o th\xe1\xba\xbf gi\xe1\xbb\x9bi',
       b'Njatjeta Bot\xc3\xab!',
       b'\xce\x93\xce\xb5\xce\xb9\xce\xb1 \xcf\x83\xce\xbf\xcf\x85 \xce\xba\xcf\x8c\xcf\x83\xce\xbc\xce\xb5!',
       b'\xe3\x81\x93\xe3\x82\x93\xe3\x81\xab\xe3\x81\xa1\xe3\x81\xaf\xe4\xb8\x96\xe7\x95\x8c',
       b'\xe4\xb8\x96\xe7\x95\x8c\xef\xbc\x8c\xe4\xbd\xa0\xe5\xa5\xbd\xef\xbc\x81',
       b'Hell\xc3\xb3, vil\xc3\xa1g!', b'Zdravo svete!',
       b'\xe0\xb9\x80\xe0\xb8\xae\xe0\xb8\xa5\xe0\xb9\x82\xe0\xb8\xa5\xe0\xb9\x80\xe0\xb8\xa7\xe0\xb8\xb4\xe0\xb8\xa5\xe0\xb8\x94\xe0\xb9\x8c'], dtype=object)

In [10]: z
Out[10]: <zarr.core.Array (12,) object>

In [11]: z.filters
Out[11]: [VLenBytes()]
```

## ``dtype='array:T'``

If ``dtype='array:T'`` is provided, this is treated as a short-hand for an array with ``dtype=object`` and ``object_codec=numcodecs.VLenArray('T')``. E.g.:

```python
In [12]: z = zarr.array([[1, 5, 7], [4], [2, 9]], dtype='array:int')

In [13]: z[:]
Out[13]: array([array([1, 5, 7]), array([4]), array([2, 9])], dtype=object)

In [14]: z
Out[14]: <zarr.core.Array (3,) object>

In [15]: z.filters
Out[15]: [VLenArray(dtype='<i8')]
```

## Extensibility/configuration

This is not something the average user will need to know, but the mapping from object types to object codecs can be updated to modify the default behaviour. 

E.g., to change the default codec for ``str`` objects:

```python
In [6]: zarr.util.object_codecs['str'] = 'msgpack'

In [7]: z = zarr.array(greetings, dtype=str)

In [8]: z
Out[8]: <zarr.core.Array (12,) object>

In [9]: z[:]
Out[9]: 
array(['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', 'Hei maailma!',
       'Xin chào thế giới', 'Njatjeta Botë!', 'Γεια σου κόσμε!', 'こんにちは世界',
       '世界，你好！', 'Helló, világ!', 'Zdravo svete!', 'เฮลโลเวิลด์'], dtype=object)

In [10]: z.filters
Out[10]: [MsgPack(encoding='utf-8')]
```

To give another example, if ``dtype=object`` is provided but no ``object_codec`` is provided, this usually raises an error:

```python
In [11]: z = zarr.array([42, 'foo', ['bar', 'baz'], {'a': 'b'}], dtype=object)
---------------------------------------------------------------------------
...
ValueError: missing object_codec for object array
```

However, a default codec for the ``object`` class (or any class) can be set, e.g.:

```python
In [12]: zarr.util.object_codecs['object'] = 'json'

In [13]: z = zarr.array([42, 'foo', ['bar', 'baz'], {'a': 'b'}], dtype=object)

In [14]: z[:]
Out[14]: array([42, 'foo', list(['bar', 'baz']), {'a': 'b'}], dtype=object)

In [15]: z
Out[15]: <zarr.core.Array (4,) object>

In [16]: z.filters
Out[16]: 
[JSON(encoding='utf-8', allow_nan=True, check_circular=True, ensure_ascii=True,
      indent=None, separators=(',', ':'), skipkeys=False, sort_keys=True,
      strict=True)]
```

## TODO

* [x] Fix PY2 test failures.
* [x] Update tutorial.
* [x] Release notes.

Resolves #206.