### PR TITLE
Copy functions

### DIFF
--- a/docs/api/convenience.rst
+++ b/docs/api/convenience.rst
@@ -6,3 +6,4 @@ Convenience functions (``zarr.convenience``)
 .. autofunction:: load
 .. autofunction:: save_array
 .. autofunction:: save_group
+.. autofunction:: copy_store

--- a/docs/api/convenience.rst
+++ b/docs/api/convenience.rst
@@ -6,4 +6,7 @@ Convenience functions (``zarr.convenience``)
 .. autofunction:: load
 .. autofunction:: save_array
 .. autofunction:: save_group
+.. autofunction:: copy
+.. autofunction:: copy_all
 .. autofunction:: copy_store
+.. autofunction:: tree

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -127,6 +127,13 @@ Enhancements
 * **Added support for ``datetime64`` and ``timedelta64`` data types**;
   :issue:`85`, :issue:`215`.
 
+* **New copy functions**. The new functions :func:`zarr.convenience.copy` and
+  :func:`zarr.convenience.copy_all` provide a way to copy groups and/or arrays
+  between HDF5 and Zarr, or between two Zarr groups. The
+  :func:`zarr.convenience.copy_store` provides a more efficient way to copy
+  data directly between two Zarr stores. :issue:`87`, :issue:`113`,
+  :issue:`137`, :issue:`217`.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -775,7 +775,7 @@ Copying/migrating data
 
 If you have some data in an HDF5 file and would like to copy some or all of it
 into a Zarr group, or vice-versa, the :func:`zarr.convenience.copy` and
-:func:`zarr.convenience.copyall` functions can be used. Here's an example
+:func:`zarr.convenience.copy_all` functions can be used. Here's an example
 copying a group named 'foo' from an HDF5 file to a Zarr group::
 
     >>> import h5py
@@ -807,7 +807,7 @@ copying a group named 'foo' from an HDF5 file to a Zarr group::
     >>> source.close()
 
 If rather than copying a single group or dataset you would like to copy all
-groups and datasets, use :func:`zarr.convenience.copyall`, e.g.::
+groups and datasets, use :func:`zarr.convenience.copy_all`, e.g.::
 
     >>> source = h5py.File('data/example.h5', mode='r')
     >>> dest = zarr.open_group('data/example2.zarr', mode='w')

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -768,6 +768,110 @@ Here is an example using S3Map to read an array created previously::
     b'Hello from the cloud!'
 
 
+.. _tutorial_copy:
+
+Copying/migrating data
+----------------------
+
+If you have some data in an HDF5 file and would like to copy some or all of it
+into a Zarr group, or vice-versa, the :func:`zarr.convenience.copy` and
+:func:`zarr.convenience.copyall` functions can be used. Here's an example
+copying a group named 'foo' from an HDF5 file to a Zarr group::
+
+    >>> import h5py
+    >>> import zarr
+    >>> import numpy as np
+    >>> source = h5py.File('data/example.h5', mode='w')
+    >>> foo = source.create_group('foo')
+    >>> baz = foo.create_dataset('bar/baz', data=np.arange(100), chunks=(50,))
+    >>> spam = source.create_dataset('spam', data=np.arange(100, 200), chunks=(30,))
+    >>> zarr.tree(source)
+    /
+     ├── foo
+     │   └── bar
+     │       └── baz (100,) int64
+     └── spam (100,) int64
+    >>> dest = zarr.open_group('data/example.zarr', mode='w')
+    >>> from sys import stdout
+    >>> zarr.copy(source['foo'], dest, log=stdout)
+    copy /foo
+    copy /foo/bar
+    copy /foo/bar/baz (100,) int64
+    all done: 3 copied, 0 skipped, 800 bytes copied
+    (3, 0, 800)
+    >>> dest.tree()  # N.B., no spam
+    /
+     └── foo
+         └── bar
+             └── baz (100,) int64
+    >>> source.close()
+
+If rather than copying a single group or dataset you would like to copy all
+groups and datasets, use :func:`zarr.convenience.copyall`, e.g.::
+
+    >>> source = h5py.File('data/example.h5', mode='r')
+    >>> dest = zarr.open_group('data/example2.zarr', mode='w')
+    >>> zarr.copy_all(source, dest, log=stdout)
+    copy /foo
+    copy /foo/bar
+    copy /foo/bar/baz (100,) int64
+    copy /spam (100,) int64
+    all done: 4 copied, 0 skipped, 1,600 bytes copied
+    (4, 0, 1600)
+    >>> dest.tree()
+    /
+     ├── foo
+     │   └── bar
+     │       └── baz (100,) int64
+     └── spam (100,) int64
+
+If you need to copy data between two Zarr groups, the
+func:`zarr.convenience.copy` and :func:`zarr.convenience.copy_all` functions can
+be used and provide the most flexibility. However, if you want to copy data
+in the most efficient way possible, without changing any configuration options,
+the :func:`zarr.convenience.copy_store` function can be used. This function
+copies data directly between the underlying stores, without any decompression or
+re-compression, and so should be faster. E.g.::
+
+    >>> import zarr
+    >>> import numpy as np
+    >>> store1 = zarr.DirectoryStore('data/example.zarr')
+    >>> root = zarr.group(store1, overwrite=True)
+    >>> baz = root.create_dataset('foo/bar/baz', data=np.arange(100), chunks=(50,))
+    >>> spam = root.create_dataset('spam', data=np.arange(100, 200), chunks=(30,))
+    >>> root.tree()
+    /
+     ├── foo
+     │   └── bar
+     │       └── baz (100,) int64
+     └── spam (100,) int64
+    >>> from sys import stdout
+    >>> store2 = zarr.ZipStore('data/example.zip', mode='w')
+    >>> zarr.copy_store(store1, store2, log=stdout)
+    copy .zgroup
+    copy foo/.zgroup
+    copy foo/bar/.zgroup
+    copy foo/bar/baz/.zarray
+    copy foo/bar/baz/0
+    copy foo/bar/baz/1
+    copy spam/.zarray
+    copy spam/0
+    copy spam/1
+    copy spam/2
+    copy spam/3
+    all done: 11 copied, 0 skipped, 1,138 bytes copied
+    (11, 0, 1138)
+    >>> new_root = zarr.group(store2)
+    >>> new_root.tree()
+    /
+     ├── foo
+     │   └── bar
+     │       └── baz (100,) int64
+     └── spam (100,) int64
+    >>> new_root['foo/bar/baz'][:]
+    array([ 0,  1,  2,  ..., 97, 98, 99])
+    >>> store2.close()  # zip stores need to be closed
+
 .. _tutorial_strings:
 
 String arrays

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,7 @@ Cython==0.27.2
 docopt==0.6.2
 fasteners==0.14.1
 flake8==3.5.0
+h5py==2.7.1
 idna==2.6
 mccabe==0.6.1
 monotonic==1.3

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -11,5 +11,5 @@ from zarr.storage import (DictStore, DirectoryStore, ZipStore, TempStore,
 from zarr.hierarchy import group, open_group, Group
 from zarr.sync import ThreadSynchronizer, ProcessSynchronizer
 from zarr.codecs import *
-from zarr.convenience import open, save, save_array, save_group, load
+from zarr.convenience import open, save, save_array, save_group, load, copy_store
 from zarr.version import version as __version__

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -11,5 +11,6 @@ from zarr.storage import (DictStore, DirectoryStore, ZipStore, TempStore,
 from zarr.hierarchy import group, open_group, Group
 from zarr.sync import ThreadSynchronizer, ProcessSynchronizer
 from zarr.codecs import *
-from zarr.convenience import open, save, save_array, save_group, load, copy_store
+from zarr.convenience import (open, save, save_array, save_group, load, copy_store,
+                              copy, copy_all, tree)
 from zarr.version import version as __version__

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -13,4 +13,5 @@ from zarr.sync import ThreadSynchronizer, ProcessSynchronizer
 from zarr.codecs import *
 from zarr.convenience import (open, save, save_array, save_group, load, copy_store,
                               copy, copy_all, tree)
+from zarr.errors import CopyError, MetadataError, PermissionError
 from zarr.version import version as __version__

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -787,13 +787,14 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists,
         raise ValueError('if_exists must be one of {!r}; found {!r}'
                          .format(valid_if_exists, if_exists))
     if dest_h5py and if_exists == 'skip_initialized':
-        raise ValueError('{!r} can only be used then copying to zarr'
+        raise ValueError('{!r} can only be used when copying to zarr'
                          .format(if_exists))
 
     # determine name to copy to
     if name is None:
         name = source.name.split('/')[-1]
         if not name:
+            # this can happen if source is the root group
             raise TypeError('source has no name, please provide the `name` '
                             'parameter to indicate a name to copy to')
 

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -5,14 +5,13 @@ from collections import Mapping
 import io
 import re
 import itertools
-import operator
 
 
 from zarr.core import Array
 from zarr.creation import open_array, normalize_store_arg, array as _create_array
 from zarr.hierarchy import open_group, group as _create_group, Group
 from zarr.storage import contains_array, contains_group
-from zarr.errors import err_path_not_found
+from zarr.errors import err_path_not_found, CopyError
 from zarr.util import normalize_storage_path, TreeViewer, buffer_size
 
 
@@ -370,8 +369,8 @@ class _LogWriter(object):
             self.needs_closing = True
         else:
             if not hasattr(log, 'write'):
-                raise TypeError('log must be a callable function, file path or file-like '
-                                'object, found %r' % log)
+                raise TypeError('log must be a callable function, file path or '
+                                'file-like object, found %r' % log)
             self.log_file = log
             self.needs_closing = False
 
@@ -391,426 +390,6 @@ class _LogWriter(object):
                 self.log_file.flush()
         elif self.log_func is not None:
             self.log_func(*args, **kwargs)
-
-
-def copy_store(source, dest, source_path='', dest_path='', excludes=None,
-               includes=None, flags=0, if_exists='raise', dry_run=False,
-               log=None):
-    """Copy data directly from the `source` store to the `dest` store. Use this
-    function when you want to copy a group or array in the most efficient way,
-    preserving all configuration and attributes. This function is more efficient
-    than the copy() or copy_all() functions because it avoids de-compressing and
-    re-compressing data, rather the compressed chunk data for each array are
-    copied directly between stores.
-
-    Parameters
-    ----------
-    source : Mapping
-        Store to copy data from.
-    dest : MutableMapping
-        Store to copy data into.
-    source_path : str, optional
-        Only copy data from under this path in the source store.
-    dest_path : str, optional
-        Copy data into this path in the destination store.
-    excludes : sequence of str, optional
-        One or more regular expressions which will be matched against keys in
-        the source store. Any matching key will not be copied.
-    includes : sequence of str, optional
-        One or more regular expressions which will be matched against keys in
-        the source store and will override any excludes also matching.
-    flags : int, optional
-        Regular expression flags used for matching excludes and includes.
-    if_exists : {'raise', 'replace', 'skip'}, optional
-        How to handle keys that already exist in the destination store. If
-        'raise' then a ValueError is raised on the first key already present
-        in the destination store. If 'replace' then any data will be replaced in
-        the destination. If 'skip' then any existing keys will not be copied.
-    dry_run : bool, optional
-        If True, don't actually copy anything, just log what would have
-        happened.
-    log : callable, file path or file-like object, optional
-        If provided, will be used to log progress information.
-
-    Examples
-    --------
-
-    >>> import zarr
-    >>> store1 = zarr.DirectoryStore('data/example.zarr')
-    >>> root = zarr.group(store1, overwrite=True)
-    >>> foo = root.create_group('foo')
-    >>> bar = foo.create_group('bar')
-    >>> baz = bar.create_dataset('baz', shape=100, chunks=50, dtype='i8')
-    >>> import numpy as np
-    >>> baz[:] = np.arange(100)
-    >>> root.tree()
-    /
-     └── foo
-         └── bar
-             └── baz (100,) int64
-    >>> import sys
-    >>> store2 = zarr.ZipStore('data/example.zip', mode='w')
-    >>> zarr.copy_store(store1, store2, log=sys.stdout)
-    copy .zgroup
-    copy foo/.zgroup
-    copy foo/bar/.zgroup
-    copy foo/bar/baz/.zarray
-    copy foo/bar/baz/0
-    copy foo/bar/baz/1
-    all done: 6 copy, 0 skip; 566 bytes copied
-    >>> new_root = zarr.group(store2)
-    >>> new_root.tree()
-    /
-     └── foo
-         └── bar
-             └── baz (100,) int64
-    >>> new_root['foo/bar/baz'][:]
-    array([ 0,  1,  2,  ..., 97, 98, 99])
-    >>> store2.close()  # zip stores need to be closed
-
-    """
-
-    # normalize paths
-    source_path = normalize_storage_path(source_path)
-    dest_path = normalize_storage_path(dest_path)
-    if source_path:
-        source_path = source_path + '/'
-    if dest_path:
-        dest_path = dest_path + '/'
-
-    # normalize excludes and includes
-    if excludes is None:
-        excludes = []
-    elif isinstance(excludes, str):
-        excludes = [excludes]
-    if includes is None:
-        includes = []
-    elif isinstance(includes, str):
-        includes = [includes]
-    excludes = [re.compile(e, flags) for e in excludes]
-    includes = [re.compile(i, flags) for i in includes]
-
-    # check if_exists parameter
-    valid_if_exists = ['raise', 'replace', 'skip']
-    if if_exists not in valid_if_exists:
-        raise ValueError('if_exists must be one of {!r}; found {!r}'
-                         .format(valid_if_exists, if_exists))
-
-    # setup counting variables
-    n_copy = 0
-    n_skip = 0
-    n_bytes_copied = 0
-
-    # setup logging
-    with _LogWriter(log) as log:
-
-        # iterate over source keys
-        for source_key in sorted(source.keys()):
-
-            # filter to keys under source path
-            if source_key.startswith(source_path):
-
-                # process excludes and includes
-                exclude = False
-                for prog in excludes:
-                    if prog.search(source_key):
-                        exclude = True
-                        break
-                if exclude:
-                    for prog in includes:
-                        if prog.search(source_key):
-                            exclude = False
-                            break
-                if exclude:
-                    continue
-
-                # map key to destination path
-                key_suffix = source_key[len(source_path):]
-                dest_key = dest_path + key_suffix
-
-                # create a descriptive label for this operation
-                descr = source_key
-                if dest_key != source_key:
-                    descr = descr + ' -> ' + dest_key
-
-                # decide what to do
-                do_copy = True
-                if if_exists != 'replace':
-                    if dest_key in dest:
-                        if if_exists == 'raise':
-                            raise ValueError('key {!r} exists in destination'
-                                             .format(dest_key))
-                        elif if_exists == 'skip':
-                            do_copy = False
-
-                # take action
-                if do_copy:
-                    n_copy += 1
-                    log('copy {}'.format(descr))
-                    if not dry_run:
-                        data = source[source_key]
-                        n_bytes_copied += buffer_size(data)
-                        dest[dest_key] = data
-                else:
-                    n_skip += 1
-                    log('skip {}'.format(descr))
-
-    # log a final message with a summary of what happened
-    if dry_run:
-        final_message = 'dry run: '
-    else:
-        final_message = 'all done: '
-    final_message += '{} copy, {} skip'.format(n_copy, n_skip)
-    if not dry_run:
-        final_message += '; {:,} bytes copied'.format(n_bytes_copied)
-    log(final_message)
-
-
-def copy(source, dest, name=None, shallow=False, without_attrs=False, log=None,
-         if_exists='raise', dry_run=False, **create_kws):
-    """Copy the `source` array or group into the `dest` group.
-
-    Parameters
-    ----------
-    source : group or array/dataset
-        A zarr group or array, or an h5py group or dataset.
-    dest : group
-        A zarr or h5py group.
-    name : str, optional
-        Name to copy the object to.
-    shallow : bool, optional
-        If True, only copy immediate children of `source`.
-    without_attrs : bool, optional
-        Do not copy user attributes.
-    log : callable, file path or file-like object, optional
-        If provided, will be used to log progress information.
-    if_exists : {'raise', 'replace', 'skip', 'skip_initialized'}, optional
-        How to handle arrays that already exist in the destination group. If
-        'raise' then a ValueError is raised on the first array already present
-        in the destination group. If 'replace' then any array will be
-        replaced in the destination. If 'skip' then any existing arrays will
-        not be copied. If 'skip_initialized' then any existing arrays with
-        all chunks initialized will not be copied (not available when copying to
-        h5py).
-    dry_run : bool, optional
-        If True, don't actually copy anything, just log what would have
-        happened.
-    **create_kws
-        Passed through to the create_dataset method when copying an array/dataset.
-
-    Examples
-    --------
-    >>> import h5py
-    >>> import zarr
-    >>> import numpy as np
-    >>> source = h5py.File('data/example.h5', mode='w')
-    >>> foo = source.create_group('foo')
-    >>> baz = foo.create_dataset('bar/baz', data=np.arange(100), chunks=(50,))
-    >>> spam = source.create_dataset('spam', data=np.arange(100, 200), chunks=(30,))
-    >>> zarr.tree(source)
-    /
-     ├── foo
-     │   └── bar
-     │       └── baz (100,) int64
-     └── spam (100,) int64
-    >>> dest = zarr.group()
-    >>> import sys
-    >>> zarr.copy(source['foo'], dest, log=sys.stdout)
-    copy /foo
-    copy /foo/bar
-    copy /foo/bar/baz (100,) int64
-    all done: 3 copy, 0 skip; 800 bytes copied
-    >>> dest.tree()  # N.B., no spam
-    /
-     └── foo
-         └── bar
-             └── baz (100,) int64
-
-    """
-
-    # setup logging
-    with _LogWriter(log) as log:
-
-        # do the copying
-        n_copy, n_skip, n_bytes_copied = _copy(
-            log, source, dest, name=name, root=True, shallow=shallow,
-            without_attrs=without_attrs, if_exists=if_exists, dry_run=dry_run,
-            **create_kws
-        )
-
-        # log a final message with a summary of what was done
-        if dry_run:
-            final_message = 'dry run: '
-        else:
-            final_message = 'all done: '
-        final_message += '{} copy, {} skip'.format(n_copy, n_skip)
-        if not dry_run:
-            final_message += '; {:,} bytes copied'.format(n_bytes_copied)
-        log(final_message)
-
-
-def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists,
-          dry_run, **create_kws):
-
-    # setup counting variables
-    n_copy = n_skip = n_bytes_copied = 0
-
-    # are we copying to/from h5py?
-    source_h5py = source.__module__.startswith('h5py.')
-    dest_h5py = dest.__module__.startswith('h5py.')
-
-    # check if_exists parameter
-    valid_if_exists = ['raise', 'replace', 'skip', 'skip_initialized']
-    if if_exists not in valid_if_exists:
-        raise ValueError('if_exists must be one of {!r}; found {!r}'
-                         .format(valid_if_exists, if_exists))
-    if dest_h5py and if_exists == 'skip_initialized':
-        raise ValueError('{!r} can only be used then copying to zarr'
-                          .format(if_exists))
-
-    # determine name to copy to
-    if name is None:
-        name = source.name.split('/')[-1]
-        if not name:
-            raise TypeError('source has no name, please provide the `name` '
-                            'parameter to indicate a name to copy to')
-
-    if hasattr(source, 'shape'):
-        # copy a dataset/array
-
-        # check if already exists, decide what to do
-        do_copy = True
-        exists = name in dest
-        if exists:
-            if if_exists == 'raise':
-                raise ValueError('an object {!r} already exists in destination '
-                                 '{!r}'.format(name, dest.name))
-            elif if_exists == 'skip':
-                do_copy = False
-            elif if_exists == 'skip_initialized':
-                ds = dest[name]
-                if ds.n_initialized == ds.n_chunks:
-                    do_copy = False
-
-        # log a message about what we're going to do
-        if do_copy:
-            n_copy += 1
-            message = 'copy {} {} {}'.format(source.name, source.shape,
-                                             source.dtype)
-        else:
-            n_skip += 1
-            message = 'skip {} {} {}'.format(source.name, source.shape,
-                                             source.dtype)
-        log(message)
-
-        # take action
-        if do_copy and not dry_run:
-
-            # clear the way
-            if exists:
-                del dest[name]
-
-            # setup creation keyword arguments
-            kws = create_kws.copy()
-
-            # setup chunks option, preserve by default
-            kws.setdefault('chunks', source.chunks)
-
-            # setup compression options
-            if source_h5py:
-                if dest_h5py:
-                    # h5py -> h5py; preserve compression options by default
-                    kws.setdefault('compression', source.compression)
-                    kws.setdefault('compression_opts', source.compression_opts)
-                    kws.setdefault('shuffle', source.shuffle)
-                else:
-                    # h5py -> zarr; use zarr default compression options
-                    pass
-            else:
-                if dest_h5py:
-                    # zarr -> h5py; use some vaguely sensible defaults
-                    kws.setdefault('chunks', True)
-                    kws.setdefault('compression', 'gzip')
-                    kws.setdefault('compression_opts', 1)
-                    kws.setdefault('shuffle', False)
-                else:
-                    # zarr -> zarr; preserve compression options by default
-                    kws.setdefault('compressor', source.compressor)
-
-            # create new dataset in destination
-            ds = dest.create_dataset(name, shape=source.shape,
-                                     dtype=source.dtype, **kws)
-
-            # copy data - N.B., go chunk by chunk to avoid loading everything
-            # into memory
-            shape = ds.shape
-            chunks = ds.chunks
-            chunk_offsets = [range(0, s, c) for s, c in zip(shape, chunks)]
-            for offset in itertools.product(*chunk_offsets):
-                sel = tuple(slice(o, min(s, o + c))
-                            for o, s, c in zip(offset, shape, chunks))
-                ds[sel] = source[sel]
-            n_bytes_copied += ds.size * ds.dtype.itemsize
-
-            # copy attributes
-            if not without_attrs:
-                ds.attrs.update(source.attrs)
-
-    elif root or not shallow:
-        # copy a group
-
-        # check if an array is in the way
-        exists_array = name in dest and hasattr(dest[name], 'shape')
-        if exists_array:
-            if if_exists == 'raise':
-                raise ValueError('an array {!r} already exists in destination '
-                                 '{!r}'.format(name, dest.name))
-            elif if_exists == 'skip':
-                n_skip += 1
-                log('skip {}'.format(source.name))
-                return
-
-        # log action
-        n_copy += 1
-        log('copy {}'.format(source.name))
-
-        if not dry_run:
-
-            # clear the way
-            if exists_array:
-                del dest[name]
-
-            # require group in destination
-            grp = dest.require_group(name)
-
-            # copy attributes
-            if not without_attrs:
-                grp.attrs.update(source.attrs)
-
-            # recurse
-            for k in source.keys():
-                c, s, b = _copy(
-                    log, source[k], grp, name=k, root=False, shallow=shallow,
-                    without_attrs=without_attrs, if_exists=if_exists,
-                    dry_run=dry_run, **create_kws)
-                n_copy += c
-                n_skip += s
-                n_bytes_copied += b
-
-        elif name in dest:
-            # dry run
-            grp = dest[name]
-            # recurse
-            for k in source.keys():
-                c, s, b = _copy(
-                    log, source[k], grp, name=k, root=False, shallow=shallow,
-                    without_attrs=without_attrs, if_exists=if_exists,
-                    dry_run=dry_run, **create_kws)
-                n_copy += c
-                n_skip += s
-                n_bytes_copied += b
-
-    return n_copy, n_skip, n_bytes_copied
 
 
 def tree(grp, expand=False, level=None):
@@ -863,6 +442,435 @@ def tree(grp, expand=False, level=None):
     return TreeViewer(grp, expand=expand, level=level)
 
 
+def _log_copy_summary(log, dry_run, n_copied, n_skipped, n_bytes_copied):
+    # log a final message with a summary of what happened
+    if dry_run:
+        message = 'dry run: '
+    else:
+        message = 'all done: '
+    message += '{:,} copied, {:,} skipped'.format(n_copied, n_skipped)
+    if not dry_run:
+        message += ', {:,} bytes copied'.format(n_bytes_copied)
+    log(message)
+
+
+def copy_store(source, dest, source_path='', dest_path='', excludes=None,
+               includes=None, flags=0, if_exists='raise', dry_run=False,
+               log=None):
+    """Copy data directly from the `source` store to the `dest` store. Use this
+    function when you want to copy a group or array in the most efficient way,
+    preserving all configuration and attributes. This function is more efficient
+    than the copy() or copy_all() functions because it avoids de-compressing and
+    re-compressing data, rather the compressed chunk data for each array are
+    copied directly between stores.
+
+    Parameters
+    ----------
+    source : Mapping
+        Store to copy data from.
+    dest : MutableMapping
+        Store to copy data into.
+    source_path : str, optional
+        Only copy data from under this path in the source store.
+    dest_path : str, optional
+        Copy data into this path in the destination store.
+    excludes : sequence of str, optional
+        One or more regular expressions which will be matched against keys in
+        the source store. Any matching key will not be copied.
+    includes : sequence of str, optional
+        One or more regular expressions which will be matched against keys in
+        the source store and will override any excludes also matching.
+    flags : int, optional
+        Regular expression flags used for matching excludes and includes.
+    if_exists : {'raise', 'replace', 'skip'}, optional
+        How to handle keys that already exist in the destination store. If
+        'raise' then a CopyError is raised on the first key already present
+        in the destination store. If 'replace' then any data will be replaced in
+        the destination. If 'skip' then any existing keys will not be copied.
+    dry_run : bool, optional
+        If True, don't actually copy anything, just log what would have
+        happened.
+    log : callable, file path or file-like object, optional
+        If provided, will be used to log progress information.
+
+    Examples
+    --------
+
+    >>> import zarr
+    >>> store1 = zarr.DirectoryStore('data/example.zarr')
+    >>> root = zarr.group(store1, overwrite=True)
+    >>> foo = root.create_group('foo')
+    >>> bar = foo.create_group('bar')
+    >>> baz = bar.create_dataset('baz', shape=100, chunks=50, dtype='i8')
+    >>> import numpy as np
+    >>> baz[:] = np.arange(100)
+    >>> root.tree()
+    /
+     └── foo
+         └── bar
+             └── baz (100,) int64
+    >>> from sys import stdout
+    >>> store2 = zarr.ZipStore('data/example.zip', mode='w')
+    >>> zarr.copy_store(store1, store2, log=stdout)
+    copy .zgroup
+    copy foo/.zgroup
+    copy foo/bar/.zgroup
+    copy foo/bar/baz/.zarray
+    copy foo/bar/baz/0
+    copy foo/bar/baz/1
+    all done: 6 copied, 0 skipped, 566 bytes copied
+    >>> new_root = zarr.group(store2)
+    >>> new_root.tree()
+    /
+     └── foo
+         └── bar
+             └── baz (100,) int64
+    >>> new_root['foo/bar/baz'][:]
+    array([ 0,  1,  2,  ..., 97, 98, 99])
+    >>> store2.close()  # zip stores need to be closed
+
+    """
+
+    # normalize paths
+    source_path = normalize_storage_path(source_path)
+    dest_path = normalize_storage_path(dest_path)
+    if source_path:
+        source_path = source_path + '/'
+    if dest_path:
+        dest_path = dest_path + '/'
+
+    # normalize excludes and includes
+    if excludes is None:
+        excludes = []
+    elif isinstance(excludes, str):
+        excludes = [excludes]
+    if includes is None:
+        includes = []
+    elif isinstance(includes, str):
+        includes = [includes]
+    excludes = [re.compile(e, flags) for e in excludes]
+    includes = [re.compile(i, flags) for i in includes]
+
+    # check if_exists parameter
+    valid_if_exists = ['raise', 'replace', 'skip']
+    if if_exists not in valid_if_exists:
+        raise ValueError('if_exists must be one of {!r}; found {!r}'
+                         .format(valid_if_exists, if_exists))
+
+    # setup counting variables
+    n_copied = 0
+    n_skipped = 0
+    n_bytes_copied = 0
+
+    # setup logging
+    with _LogWriter(log) as log:
+
+        # iterate over source keys
+        for source_key in sorted(source.keys()):
+
+            # filter to keys under source path
+            if source_key.startswith(source_path):
+
+                # process excludes and includes
+                exclude = False
+                for prog in excludes:
+                    if prog.search(source_key):
+                        exclude = True
+                        break
+                if exclude:
+                    for prog in includes:
+                        if prog.search(source_key):
+                            exclude = False
+                            break
+                if exclude:
+                    continue
+
+                # map key to destination path
+                key_suffix = source_key[len(source_path):]
+                dest_key = dest_path + key_suffix
+
+                # create a descriptive label for this operation
+                descr = source_key
+                if dest_key != source_key:
+                    descr = descr + ' -> ' + dest_key
+
+                # decide what to do
+                do_copy = True
+                if if_exists != 'replace':
+                    if dest_key in dest:
+                        if if_exists == 'raise':
+                            raise CopyError('key {!r} exists in destination'
+                                            .format(dest_key))
+                        elif if_exists == 'skip':
+                            do_copy = False
+
+                # take action
+                if do_copy:
+                    log('copy {}'.format(descr))
+                    if not dry_run:
+                        data = source[source_key]
+                        n_bytes_copied += buffer_size(data)
+                        dest[dest_key] = data
+                    n_copied += 1
+                else:
+                    log('skip {}'.format(descr))
+                    n_skipped += 1
+
+        # log a final message with a summary of what happened
+        _log_copy_summary(log, dry_run, n_copied, n_skipped, n_bytes_copied)
+
+
+def copy(source, dest, name=None, shallow=False, without_attrs=False, log=None,
+         if_exists='raise', dry_run=False, return_stats=False, **create_kws):
+    """Copy the `source` array or group into the `dest` group.
+
+    Parameters
+    ----------
+    source : group or array/dataset
+        A zarr group or array, or an h5py group or dataset.
+    dest : group
+        A zarr or h5py group.
+    name : str, optional
+        Name to copy the object to.
+    shallow : bool, optional
+        If True, only copy immediate children of `source`.
+    without_attrs : bool, optional
+        Do not copy user attributes.
+    log : callable, file path or file-like object, optional
+        If provided, will be used to log progress information.
+    if_exists : {'raise', 'replace', 'skip', 'skip_initialized'}, optional
+        How to handle arrays that already exist in the destination group. If
+        'raise' then a CopyError is raised on the first array already present
+        in the destination group. If 'replace' then any array will be
+        replaced in the destination. If 'skip' then any existing arrays will
+        not be copied. If 'skip_initialized' then any existing arrays with
+        all chunks initialized will not be copied (not available when copying to
+        h5py).
+    dry_run : bool, optional
+        If True, don't actually copy anything, just log what would have
+        happened.
+    return_stats : bool, optional
+        If True, return n_copied, n_skipped, n_bytes_copied.
+    **create_kws
+        Passed through to the create_dataset method when copying an array/dataset.
+
+    Examples
+    --------
+    >>> import h5py
+    >>> import zarr
+    >>> import numpy as np
+    >>> source = h5py.File('data/example.h5', mode='w')
+    >>> foo = source.create_group('foo')
+    >>> baz = foo.create_dataset('bar/baz', data=np.arange(100), chunks=(50,))
+    >>> spam = source.create_dataset('spam', data=np.arange(100, 200), chunks=(30,))
+    >>> zarr.tree(source)
+    /
+     ├── foo
+     │   └── bar
+     │       └── baz (100,) int64
+     └── spam (100,) int64
+    >>> dest = zarr.group()
+    >>> from sys import stdout
+    >>> zarr.copy(source['foo'], dest, log=stdout)
+    copy /foo
+    copy /foo/bar
+    copy /foo/bar/baz (100,) int64
+    all done: 3 copied, 0 skipped, 800 bytes copied
+    >>> dest.tree()  # N.B., no spam
+    /
+     └── foo
+         └── bar
+             └── baz (100,) int64
+
+    """
+
+    # setup logging
+    with _LogWriter(log) as log:
+
+        # do the copying
+        n_copied, n_skipped, n_bytes_copied = _copy(
+            log, source, dest, name=name, root=True, shallow=shallow,
+            without_attrs=without_attrs, if_exists=if_exists, dry_run=dry_run,
+            **create_kws
+        )
+
+        # log a final message with a summary of what happened
+        _log_copy_summary(log, dry_run, n_copied, n_skipped, n_bytes_copied)
+
+        if return_stats:
+            return n_copied, n_skipped, n_bytes_copied
+
+
+def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists,
+          dry_run, **create_kws):
+    # N.B., if this is a dry run, dest may be None
+
+    # setup counting variables
+    n_copied = n_skipped = n_bytes_copied = 0
+
+    # are we copying to/from h5py?
+    source_h5py = source.__module__.startswith('h5py.')
+    dest_h5py = dest is not None and dest.__module__.startswith('h5py.')
+
+    # check if_exists parameter
+    valid_if_exists = ['raise', 'replace', 'skip', 'skip_initialized']
+    if if_exists not in valid_if_exists:
+        raise ValueError('if_exists must be one of {!r}; found {!r}'
+                         .format(valid_if_exists, if_exists))
+    if dest_h5py and if_exists == 'skip_initialized':
+        raise ValueError('{!r} can only be used then copying to zarr'
+                         .format(if_exists))
+
+    # determine name to copy to
+    if name is None:
+        name = source.name.split('/')[-1]
+        if not name:
+            raise TypeError('source has no name, please provide the `name` '
+                            'parameter to indicate a name to copy to')
+
+    if hasattr(source, 'shape'):
+        # copy a dataset/array
+
+        # check if already exists, decide what to do
+        do_copy = True
+        exists = dest is not None and name in dest
+        if exists:
+            if if_exists == 'raise':
+                raise CopyError('an object {!r} already exists in destination '
+                                '{!r}'.format(name, dest.name))
+            elif if_exists == 'skip':
+                do_copy = False
+            elif if_exists == 'skip_initialized':
+                ds = dest[name]
+                if ds.nchunks_initialized == ds.nchunks:
+                    do_copy = False
+
+        # take action
+        if do_copy:
+
+            # log a message about what we're going to do
+            log('copy {} {} {}'.format(source.name, source.shape, source.dtype))
+
+            if not dry_run:
+
+                # clear the way
+                if exists:
+                    del dest[name]
+
+                # setup creation keyword arguments
+                kws = create_kws.copy()
+
+                # setup chunks option, preserve by default
+                kws.setdefault('chunks', source.chunks)
+
+                # setup compression options
+                if source_h5py:
+                    if dest_h5py:
+                        # h5py -> h5py; preserve compression options by default
+                        kws.setdefault('compression', source.compression)
+                        kws.setdefault('compression_opts', source.compression_opts)
+                        kws.setdefault('shuffle', source.shuffle)
+                    else:
+                        # h5py -> zarr; use zarr default compression options
+                        pass
+                else:
+                    if dest_h5py:
+                        # zarr -> h5py; use some vaguely sensible defaults
+                        kws.setdefault('chunks', True)
+                        kws.setdefault('compression', 'gzip')
+                        kws.setdefault('compression_opts', 1)
+                        kws.setdefault('shuffle', False)
+                    else:
+                        # zarr -> zarr; preserve compression options by default
+                        kws.setdefault('compressor', source.compressor)
+
+                # create new dataset in destination
+                ds = dest.create_dataset(name, shape=source.shape,
+                                         dtype=source.dtype, **kws)
+
+                # copy data - N.B., go chunk by chunk to avoid loading
+                # everything into memory
+                shape = ds.shape
+                chunks = ds.chunks
+                chunk_offsets = [range(0, s, c) for s, c in zip(shape, chunks)]
+                for offset in itertools.product(*chunk_offsets):
+                    sel = tuple(slice(o, min(s, o + c))
+                                for o, s, c in zip(offset, shape, chunks))
+                    ds[sel] = source[sel]
+                n_bytes_copied += ds.size * ds.dtype.itemsize
+
+                # copy attributes
+                if not without_attrs:
+                    ds.attrs.update(source.attrs)
+
+            n_copied += 1
+
+        else:
+            log('skip {} {} {}'.format(source.name, source.shape, source.dtype))
+            n_skipped += 1
+
+    elif root or not shallow:
+        # copy a group
+
+        # check if an array is in the way
+        do_copy = True
+        exists_array = (dest is not None and
+                        name in dest and
+                        hasattr(dest[name], 'shape'))
+        if exists_array:
+            if if_exists == 'raise':
+                raise CopyError('an array {!r} already exists in destination '
+                                '{!r}'.format(name, dest.name))
+            elif if_exists == 'skip':
+                do_copy = False
+
+        # take action
+        if do_copy:
+
+            # log action
+            log('copy {}'.format(source.name))
+
+            if not dry_run:
+
+                # clear the way
+                if exists_array:
+                    del dest[name]
+
+                # require group in destination
+                grp = dest.require_group(name)
+
+                # copy attributes
+                if not without_attrs:
+                    grp.attrs.update(source.attrs)
+
+            else:
+
+                # setup for dry run without creating any groups in the
+                # destination
+                if dest is not None:
+                    grp = dest.get(name, None)
+                else:
+                    grp = None
+
+            # recurse
+            for k in source.keys():
+                c, s, b = _copy(
+                    log, source[k], grp, name=k, root=False, shallow=shallow,
+                    without_attrs=without_attrs, if_exists=if_exists,
+                    dry_run=dry_run, **create_kws)
+                n_copied += c
+                n_skipped += s
+                n_bytes_copied += b
+
+            n_copied += 1
+
+        else:
+            log('skip {}'.format(source.name))
+            n_skipped += 1
+
+    return n_copied, n_skipped, n_bytes_copied
+
+
 def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
              if_exists='raise', dry_run=False, **create_kws):
     """Copy all children of the `source` group into the `dest` group.
@@ -881,7 +889,7 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
         If provided, will be used to log progress information.
     if_exists : {'raise', 'replace', 'skip', 'skip_initialized'}, optional
         How to handle arrays that already exist in the destination group. If
-        'raise' then a ValueError is raised on the first array already present
+        'raise' then a CopyError is raised on the first array already present
         in the destination group. If 'replace' then any array will be
         replaced in the destination. If 'skip' then any existing arrays will
         not be copied. If 'skip_initialized' then any existing arrays with
@@ -916,7 +924,7 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
     copy /foo/bar
     copy /foo/bar/baz (100,) int64
     copy /spam (100,) int64
-    all done: 4 copy, 0 skip; 1,600 bytes copied
+    all done: 4 copied, 0 skipped, 1,600 bytes copied
     >>> dest.tree()
     /
      ├── foo
@@ -927,7 +935,7 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
     """
 
     # setup counting variables
-    n_copy = n_skip = n_bytes_copied = 0
+    n_copied = n_skipped = n_bytes_copied = 0
 
     # setup logging
     with _LogWriter(log) as log:
@@ -937,16 +945,9 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
                 log, source[k], dest, name=k, root=False, shallow=shallow,
                 without_attrs=without_attrs, if_exists=if_exists,
                 dry_run=dry_run, **create_kws)
-            n_copy += c
-            n_skip += s
+            n_copied += c
+            n_skipped += s
             n_bytes_copied += b
 
-        # log a final message with a summary of what was done
-        if dry_run:
-            final_message = 'dry run: '
-        else:
-            final_message = 'all done: '
-        final_message += '{} copy, {} skip'.format(n_copy, n_skip)
-        if not dry_run:
-            final_message += '; {:,} bytes copied'.format(n_bytes_copied)
-        log(final_message)
+        # log a final message with a summary of what happened
+        _log_copy_summary(log, dry_run, n_copied, n_skipped, n_bytes_copied)

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -511,7 +511,7 @@ def copy_store(source, dest, source_path='', dest_path='', excludes=None,
 
 def copy(source, dest, name=None, shallow=False, without_attrs=False, log=None,
          **create_kws):
-    """Copy the source object into the given destination.
+    """Copy the `source` array or group into the `dest` group.
 
     Parameters
     ----------
@@ -686,7 +686,7 @@ def tree(grp, expand=False, level=None):
 
 
 def copy_all(source, dest, shallow=False, without_attrs=False, log=None, **create_kws):
-    """Copy all children of the source group into the destination group.
+    """Copy all children of the `source` group into the `dest` group.
 
     Parameters
     ----------

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -636,6 +636,11 @@ def copy_store(source, dest, source_path='', dest_path='', excludes=None,
     return n_copied, n_skipped, n_bytes_copied
 
 
+def _check_dest_is_group(dest):
+    if not hasattr(dest, 'create_dataset'):
+        raise ValueError('dest must be a group, got {!r}'.format(dest))
+
+
 def copy(source, dest, name=None, shallow=False, without_attrs=False, log=None,
          if_exists='raise', dry_run=False, **create_kws):
     """Copy the `source` array or group into the `dest` group.
@@ -707,6 +712,9 @@ def copy(source, dest, name=None, shallow=False, without_attrs=False, log=None,
              └── baz (100,) int64
 
     """
+
+    # value checks
+    _check_dest_is_group(dest)
 
     # setup logging
     with _LogWriter(log) as log:
@@ -972,6 +980,9 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
      └── spam (100,) int64
 
     """
+
+    # value checks
+    _check_dest_is_group(dest)
 
     # setup counting variables
     n_copied = n_skipped = n_bytes_copied = 0

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -793,9 +793,11 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists,
                         kws.setdefault('compression', source.compression)
                         kws.setdefault('compression_opts', source.compression_opts)
                         kws.setdefault('shuffle', source.shuffle)
+                        kws.setdefault('fletcher32', source.fletcher32)
+                        kws.setdefault('fillvalue', source.fillvalue)
                     else:
                         # h5py -> zarr; use zarr default compression options
-                        pass
+                        kws.setdefault('fill_value', source.fillvalue)
                 else:
                     if dest_h5py:
                         # zarr -> h5py; use some vaguely sensible defaults
@@ -803,9 +805,13 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists,
                         kws.setdefault('compression', 'gzip')
                         kws.setdefault('compression_opts', 1)
                         kws.setdefault('shuffle', False)
+                        kws.setdefault('fillvalue', source.fill_value)
                     else:
                         # zarr -> zarr; preserve compression options by default
                         kws.setdefault('compressor', source.compressor)
+                        kws.setdefault('filters', source.filters)
+                        kws.setdefault('order', source.order)
+                        kws.setdefault('fill_value', source.fill_value)
 
                 # create new dataset in destination
                 ds = dest.create_dataset(name, shape=source.shape,

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -396,8 +396,9 @@ def copy_store(source, dest, source_path='', dest_path='', excludes=None,
     """Copy data directly from the `source` store to the `dest` store. Use this
     function when you want to copy a group or array in the most efficient way,
     preserving all configuration and attributes. This function is more efficient
-    because it avoids de-compressing and re-compressing data, rather the compressed
-    chunk data for each array are copied directly between stores.
+    than the copy() or copy_all() functions because it avoids de-compressing and
+    re-compressing data, rather the compressed chunk data for each array are copied
+    directly between stores.
 
     Parameters
     ----------
@@ -423,7 +424,8 @@ def copy_store(source, dest, source_path='', dest_path='', excludes=None,
     Examples
     --------
     >>> import zarr
-    >>> root = zarr.group()
+    >>> store1 = zarr.DirectoryStore('data/example.zarr')
+    >>> root = zarr.group(store1, overwrite=True)
     >>> foo = root.create_group('foo')
     >>> bar = foo.create_group('bar')
     >>> baz = bar.create_dataset('baz', shape=100, chunks=50, dtype='i8')
@@ -434,17 +436,16 @@ def copy_store(source, dest, source_path='', dest_path='', excludes=None,
      └── foo
          └── bar
              └── baz (100,) int64
-    >>> source = root.store
-    >>> dest = dict()  # or could be any other type of store
     >>> import sys
-    >>> zarr.copy_store(source, dest, log=sys.stdout)
+    >>> store2 = zarr.ZipStore('data/example.zip', mode='w')  # or any type of store
+    >>> zarr.copy_store(store1, store2, log=sys.stdout)
     .zgroup -> .zgroup
     foo/.zgroup -> foo/.zgroup
     foo/bar/.zgroup -> foo/bar/.zgroup
     foo/bar/baz/.zarray -> foo/bar/baz/.zarray
     foo/bar/baz/0 -> foo/bar/baz/0
     foo/bar/baz/1 -> foo/bar/baz/1
-    >>> new_root = zarr.group(dest)
+    >>> new_root = zarr.group(store2)
     >>> new_root.tree()
     /
      └── foo
@@ -452,6 +453,7 @@ def copy_store(source, dest, source_path='', dest_path='', excludes=None,
              └── baz (100,) int64
     >>> new_root['foo/bar/baz'][:]
     array([ 0,  1,  2,  ..., 97, 98, 99])
+    >>> store2.close()  # zip stores need to be closed
 
     """
 

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -593,7 +593,7 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, overwrite, **cr
                 log('delete {}/{}'.format(dest.name, name))
                 del dest[name]
             else:
-                raise ValueError('object {!r} already exists in destination '
+                raise ValueError('an object {!r} already exists in destination '
                                  '{!r}'.format(name, dest.name))
 
         # setup creation keyword arguments

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -739,4 +739,3 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None, **creat
         for k in source.keys():
             _copy(log, source[k], dest, name=k, root=False, shallow=shallow,
                   without_attrs=without_attrs, **create_kws)
-

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -544,7 +544,11 @@ def copy(source, dest, name=None, shallow=False, without_attrs=False, log=None,
      │       └── baz (100,) int64
      └── spam (100,) int64
     >>> dest = zarr.group()
-    >>> zarr.copy(source['foo'], dest)
+    >>> import sys
+    >>> zarr.copy(source['foo'], dest, log=sys.stdout)
+    /foo -> /foo
+    /foo/bar -> /foo/bar
+    /foo/bar/baz -> /foo/bar/baz
     >>> dest.tree()  # N.B., no spam
     /
      └── foo
@@ -617,6 +621,7 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, **create_kws):
 
         # creat new group in destination
         grp = dest.create_group(name)
+        log('{} -> {}'.format(source.name, grp.name))
 
         # copy attributes
         if not without_attrs:
@@ -712,7 +717,12 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None, **creat
      │       └── baz (100,) int64
      └── spam (100,) int64
     >>> dest = zarr.group()
-    >>> zarr.copy_all(source, dest)
+    >>> import sys
+    >>> zarr.copy_all(source, dest, log=sys.stdout)
+    /foo -> /foo
+    /foo/bar -> /foo/bar
+    /foo/bar/baz -> /foo/bar/baz
+    /spam -> /spam
     >>> dest.tree()
     /
      ├── foo

--- a/zarr/errors.py
+++ b/zarr/errors.py
@@ -9,6 +9,10 @@ class MetadataError(Exception):
     pass
 
 
+class CopyError(RuntimeError):
+    pass
+
+
 def err_contains_group(path):
     raise ValueError('path %r contains a group' % path)
 

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -314,3 +314,9 @@ def test_copy_h5py_zarr():
 def test_copy_zarr_h5py():
     # zarr -> h5py
     _test_copy(group, temp_h5f)
+
+
+@pytest.mark.skipif(not have_h5py, reason='h5py not installed')
+def test_copy_h5py_h5py():
+    # zarr -> h5py
+    _test_copy(temp_h5f, temp_h5f)

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -148,3 +148,32 @@ def test_copy_store():
                 else:
                     assert key not in dest
                     assert ('new/' + key) not in dest
+
+    # with excludes/includes
+    source = dict()
+    source['foo'] = b'xxx'
+    source['bar/baz'] = b'yyy'
+    source['bar/qux'] = b'zzz'
+    # single excludes
+    dest = dict()
+    excludes = 'f.*'
+    copy_store(source, dest, excludes=excludes)
+    assert len(dest) == 2
+    assert 'foo' not in dest
+    # multiple excludes
+    dest = dict()
+    excludes = 'b.z', '.*x'
+    copy_store(source, dest, excludes=excludes)
+    assert len(dest) == 1
+    assert 'foo' in dest
+    assert 'bar/baz' not in dest
+    assert 'bar/qux' not in dest
+    # excludes and includes
+    dest = dict()
+    excludes = 'b.*'
+    includes = '.*x'
+    copy_store(source, dest, excludes=excludes, includes=includes)
+    assert len(dest) == 2
+    assert 'foo' in dest
+    assert 'bar/baz' not in dest
+    assert 'bar/qux' in dest

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -218,7 +218,8 @@ class TestCopyStore(unittest.TestCase):
             copy_store(source, dest, if_exists='foobar')
 
 
-def check_copied_array(original, copied, without_attrs=False, expect_props=None):
+def check_copied_array(original, copied, without_attrs=False,
+                       expect_props=None):
 
     # setup
     source_h5py = original.__module__.startswith('h5py.')
@@ -544,11 +545,12 @@ class TestCopy(unittest.TestCase):
         copy(source['foo'], dest, dry_run=True, log=print)
 
         # file name
-        with tempfile.NamedTemporaryFile() as f:
-            copy(source['foo'], dest, dry_run=True, log=f.name)
+        fn = tempfile.mktemp()
+        atexit.register(os.remove, fn)
+        copy(source['foo'], dest, dry_run=True, log=fn)
 
         # file
-        with tempfile.NamedTemporaryFile(mode='w') as f:
+        with tempfile.TemporaryFile(mode='w') as f:
             copy(source['foo'], dest, dry_run=True, log=f)
 
         # bad option

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -335,6 +335,14 @@ class TestCopy(unittest.TestCase):
         copy(source['spam'], dest)
         check_copied_array(source['spam'], dest['spam'])
 
+    def test_copy_bad_dest(self):
+        source = self.source
+
+        # try to copy to an array, dest must be a group
+        dest = self.new_dest().create_dataset('eggs', shape=(100,))
+        with pytest.raises(ValueError):
+            copy(source['foo/bar/baz'], dest)
+
     def test_copy_array_name(self):
         source = self.source
         dest = self.new_dest()

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -274,7 +274,8 @@ def _test_copy(new_source, new_dest):
     foo.attrs['experiment'] = 'weird science'
     baz = foo.create_dataset('bar/baz', data=np.arange(100), chunks=(50,))
     baz.attrs['units'] = 'metres'
-    source.create_dataset('spam', data=np.arange(100, 200), chunks=(30,))
+    source.create_dataset('spam', data=np.arange(100, 200).reshape(20, 5),
+                          chunks=(10, 2))
 
     # copy array with default options
     copy(source['foo/bar/baz'], dest)

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -315,8 +315,14 @@ class TestCopy(unittest.TestCase):
         foo.attrs['experiment'] = 'weird science'
         baz = foo.create_dataset('bar/baz', data=np.arange(100), chunks=(50,))
         baz.attrs['units'] = 'metres'
+        if self.source_h5py:
+            extra_kws = dict(compression='gzip', compression_opts=3, fillvalue=84,
+                             shuffle=True, fletcher32=True)
+        else:
+            extra_kws = dict(compressor=Zlib(3), order='F', fill_value=42,
+                             filters=[Adler32()])
         source.create_dataset('spam', data=np.arange(100, 200).reshape(20, 5),
-                              chunks=(10, 2))
+                              chunks=(10, 2), dtype='i2', **extra_kws)
         self.source = source
 
     def test_copy_array(self):
@@ -326,6 +332,8 @@ class TestCopy(unittest.TestCase):
         # copy array with default options
         copy(source['foo/bar/baz'], dest)
         check_copied_array(source['foo/bar/baz'], dest['baz'])
+        copy(source['spam'], dest)
+        check_copied_array(source['spam'], dest['spam'])
 
     def test_copy_array_name(self):
         source = self.source

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -585,6 +585,7 @@ def temp_h5f():
     fn = tempfile.mktemp()
     atexit.register(os.remove, fn)
     h5f = h5py.File(fn, mode='w')
+    atexit.register(lambda v: v.close(), h5f)
     return h5f
 
 

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -352,7 +352,7 @@ def _test_copy(new_source, new_dest):
     with pytest.raises(ValueError):
         copy(source['foo/bar/baz'], dest)
     assert (10,) == dest['baz'].shape
-    copy(source['foo/bar/baz'], dest, overwrite=True)
+    copy(source['foo/bar/baz'], dest, if_exists='replace')
     check_copied_array(source['foo/bar/baz'], dest['baz'])
 
     # copy array, dest group in the way
@@ -361,7 +361,7 @@ def _test_copy(new_source, new_dest):
     with pytest.raises(ValueError):
         copy(source['foo/bar/baz'], dest)
     assert not hasattr(dest['baz'], 'shape')
-    copy(source['foo/bar/baz'], dest, overwrite=True)
+    copy(source['foo/bar/baz'], dest, if_exists='replace')
     check_copied_array(source['foo/bar/baz'], dest['baz'])
 
     # copy group, default options
@@ -392,7 +392,7 @@ def _test_copy(new_source, new_dest):
     with pytest.raises(ValueError):
         copy(source['foo'], dest)
     assert dest['foo/bar'].shape == (10,)
-    copy(source['foo'], dest, overwrite=True)
+    copy(source['foo'], dest, if_exists='replace')
     check_copied_group(source['foo'], dest['foo'])
 
 

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -90,9 +90,7 @@ def test_lazy_loader():
     assert_array_equal(bar, loader['bar'])
 
 
-def test_copy_store():
-
-    # no paths
+def test_copy_store_no_paths():
     source = dict()
     source['foo'] = b'xxx'
     source['bar'] = b'yyy'
@@ -102,7 +100,8 @@ def test_copy_store():
     for key in source:
         assert source[key] == dest[key]
 
-    # with source path
+
+def test_copy_store_source_path():
     source = dict()
     source['foo'] = b'xxx'
     source['bar/baz'] = b'yyy'
@@ -119,7 +118,8 @@ def test_copy_store():
             else:
                 assert key not in dest
 
-    # with dest path
+
+def test_copy_store_dest_path():
     source = dict()
     source['foo'] = b'xxx'
     source['bar/baz'] = b'yyy'
@@ -133,7 +133,8 @@ def test_copy_store():
             dest_key = 'new/' + key
             assert source[key] == dest[dest_key]
 
-    # with source and dest path
+
+def test_copy_store_source_dest_path():
     source = dict()
     source['foo'] = b'xxx'
     source['bar/baz'] = b'yyy'
@@ -152,7 +153,8 @@ def test_copy_store():
                     assert key not in dest
                     assert ('new/' + key) not in dest
 
-    # with excludes/includes
+
+def test_copy_store_excludes_includes():
     source = dict()
     source['foo'] = b'xxx'
     source['bar/baz'] = b'yyy'
@@ -180,6 +182,49 @@ def test_copy_store():
     assert 'foo' in dest
     assert 'bar/baz' not in dest
     assert 'bar/qux' in dest
+
+
+def test_copy_store_dry_run():
+    source = dict()
+    source['foo'] = b'xxx'
+    source['bar/baz'] = b'yyy'
+    source['bar/qux'] = b'zzz'
+    dest = dict()
+    copy_store(source, dest, dry_run=True)
+    assert 0 == len(dest)
+
+
+def test_copy_store_if_exists():
+
+    # setup
+    source = dict()
+    source['foo'] = b'xxx'
+    source['bar/baz'] = b'yyy'
+    source['bar/qux'] = b'zzz'
+    dest = dict()
+    dest['bar/baz'] = b'mmm'
+
+    # default ('raise')
+    with pytest.raises(ValueError):
+        copy_store(source, dest)
+
+    # explicit 'raise'
+    with pytest.raises(ValueError):
+        copy_store(source, dest, if_exists='raise')
+
+    # skip
+    copy_store(source, dest, if_exists='skip')
+    assert 3 == len(dest)
+    assert dest['foo'] == b'xxx'
+    assert dest['bar/baz'] == b'mmm'
+    assert dest['bar/qux'] == b'zzz'
+
+    # replace
+    copy_store(source, dest, if_exists='replace')
+    assert 3 == len(dest)
+    assert dest['foo'] == b'xxx'
+    assert dest['bar/baz'] == b'yyy'
+    assert dest['bar/qux'] == b'zzz'
 
 
 def check_copied_array(original, copied, without_attrs=False, expect_props=None):


### PR DESCRIPTION
This PR adds some convenience functions for copying data between zarr groups or stores, or for copying data between h5py and zarr. The following new functions are proposed:

* ``zarr.copy(source, dest, ...)`` - copy the ``source`` h5py or zarr group or array into the ``dest`` h5py or zarr group.
* ``zarr.copy_all(source, dest, ...)`` - copy all children of the ``source`` h5py or zarr group into the ``dest`` h5py or zarr group.
* ``zarr.copy_store(source, dest, ...)`` - copy all (key, value) pairs from the ``source`` store to the ``dest`` store.

Further details and examples are given in the function docstrings.

Resolves #87, resolves #113, resolves #137.

TODO:
* [x] consider using require_group to allow for destination groups already existing
* [x] test coverage up
* [x] address all @jakirkham review comments
* [x] tutorial section
* [x] release notes

POSTPONED:
* consider Group.copy() method?
* consider ``delete=True/False`` option analogous to rsync?
