### PR TITLE
LRU store cache

### DIFF
--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -23,8 +23,9 @@ Storage (``zarr.storage``)
 
 .. autoclass:: LRUStoreCache
 
-    .. automethod:: clear_values
-    .. automethod:: clear_keys
+    .. automethod:: invalidate
+    .. automethod:: invalidate_values
+    .. automethod:: invalidate_keys
 
 .. autofunction:: init_array
 .. autofunction:: init_group

--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -21,6 +21,17 @@ Storage (``zarr.storage``)
     .. automethod:: close
     .. automethod:: flush
 
+.. autoclass:: LRUStoreCache
+
+    .. automethod:: clear_values
+    .. automethod:: clear_keys
+
 .. autofunction:: init_array
 .. autofunction:: init_group
+.. autofunction:: contains_array
+.. autofunction:: contains_group
+.. autofunction:: listdir
+.. autofunction:: rmdir
+.. autofunction:: getsize
+.. autofunction:: rename
 .. autofunction:: migrate_1to2

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -127,6 +127,11 @@ Enhancements
 * **Added support for ``datetime64`` and ``timedelta64`` data types**;
   :issue:`85`, :issue:`215`.
 
+* **New LRUStoreCache class**. The class :class:`zarr.storage.LRUStoreCache` has been
+  added and provides a means to locally cache data in memory from a store that may be
+  slow, e.g., a store that retrieves data from a remote server via the network;
+  :issue:`223`.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -7,7 +7,7 @@ from zarr.core import Array
 from zarr.creation import (empty, zeros, ones, full, array, empty_like, zeros_like,
                            ones_like, full_like, open_array, open_like, create)
 from zarr.storage import (DictStore, DirectoryStore, ZipStore, TempStore,
-                          NestedDirectoryStore, DBMStore, LMDBStore)
+                          NestedDirectoryStore, DBMStore, LMDBStore, LRUStoreCache)
 from zarr.hierarchy import group, open_group, Group
 from zarr.sync import ThreadSynchronizer, ProcessSynchronizer
 from zarr.codecs import *

--- a/zarr/compat.py
+++ b/zarr/compat.py
@@ -16,9 +16,16 @@ if PY2:  # pragma: py3 no cover
     class PermissionError(Exception):
         pass
 
+    def OrderedDict_move_to_end(od, key):
+        od[key] = od.pop(key)
+
+
 else:  # pragma: py2 no cover
 
     text_type = str
     binary_type = bytes
     from functools import reduce
     PermissionError = PermissionError
+
+    def OrderedDict_move_to_end(od, key):
+        od.move_to_end(key)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -28,10 +28,10 @@ from zarr.util import (normalize_shape, normalize_chunks, normalize_order,
                        normalize_storage_path, buffer_size,
                        normalize_fill_value, nolock, normalize_dtype)
 from zarr.meta import encode_array_metadata, encode_group_metadata
-from zarr.compat import PY2, binary_type
+from zarr.compat import PY2, binary_type, OrderedDict_move_to_end
 from numcodecs.registry import codec_registry
-from zarr.errors import (err_contains_group, err_contains_array, err_path_not_found,
-                         err_bad_compressor, err_fspath_exists_notdir, err_read_only)
+from zarr.errors import (err_contains_group, err_contains_array, err_bad_compressor,
+                         err_fspath_exists_notdir, err_read_only)
 
 
 array_meta_key = '.zarray'
@@ -1783,7 +1783,7 @@ class LRUStoreCache(MutableMapping):
                 # cache hit if no KeyError is raised
                 self.hits += 1
                 # treat the end as most recently used
-                self._values_cache.move_to_end(key)
+                OrderedDict_move_to_end(self._values_cache, key)
 
         except KeyError:
             # cache miss, retrieve value from the store

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -18,7 +18,8 @@ import pytest
 
 
 from zarr.storage import (DirectoryStore, init_array, init_group, NestedDirectoryStore,
-                          DBMStore, LMDBStore, atexit_rmtree, atexit_rmglob)
+                          DBMStore, LMDBStore, atexit_rmtree, atexit_rmglob,
+                          LRUStoreCache)
 from zarr.core import Array
 from zarr.errors import PermissionError
 from zarr.compat import PY2, text_type, binary_type
@@ -1615,3 +1616,13 @@ class TestArrayNoCacheMetadata(TestArray):
     def test_object_arrays_danger(self):
         # skip this one as it only works if metadata are cached
         pass
+
+
+class TestArrayWithStoreCache(TestArray):
+
+    @staticmethod
+    def create_array(read_only=False, **kwargs):
+        store = LRUStoreCache(dict(), max_size=None)
+        kwargs.setdefault('compressor', Zlib(level=1))
+        init_array(store, **kwargs)
+        return Array(store, read_only=read_only)

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -20,7 +20,8 @@ import pytest
 
 from zarr.storage import (DictStore, DirectoryStore, ZipStore, init_group, init_array,
                           array_meta_key, group_meta_key, atexit_rmtree,
-                          NestedDirectoryStore, DBMStore, LMDBStore, atexit_rmglob)
+                          NestedDirectoryStore, DBMStore, LMDBStore, atexit_rmglob,
+                          LRUStoreCache)
 from zarr.core import Array
 from zarr.compat import PY2, text_type
 from zarr.hierarchy import Group, group, open_group
@@ -943,6 +944,14 @@ class TestGroupWithChunkStore(TestGroup):
         expect = ['foo/' + str(i) for i in range(10)]
         actual = sorted(chunk_store.keys())
         eq(expect, actual)
+
+
+class TestGroupWithStoreCache(TestGroup):
+
+    @staticmethod
+    def create_store():
+        store = LRUStoreCache(dict(), max_size=None)
+        return store, None
 
 
 def test_group():

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -889,10 +889,14 @@ class TestLRUStoreCache(StoreTests, unittest.TestCase):
         assert 2 == cache.hits
         assert 1 == cache.misses
 
-        # manually clear all cached values
-        cache.clear_values()
+        # manually invalidate all cached values
+        cache.invalidate_values()
         assert b'zzz' == cache['foo']
         assert 2 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+        cache.invalidate()
+        assert b'zzz' == cache['foo']
+        assert 3 == store.counter['__getitem__', 'foo']
         assert 2 == store.counter['__setitem__', 'foo']
 
         # test __delitem__
@@ -1037,20 +1041,20 @@ class TestLRUStoreCache(StoreTests, unittest.TestCase):
         assert keys == sorted(cache.keys())
         assert 2 == store.counter['keys']
 
-        # manually clear keys
-        cache.clear_keys()
+        # manually invalidate keys
+        cache.invalidate_keys()
         keys = sorted(cache.keys())
         assert keys == ['bar', 'baz', 'foo']
         assert 3 == store.counter['keys']
         assert 0 == store.counter['__contains__', 'foo']
         assert 0 == store.counter['__iter__']
-        cache.clear_keys()
+        cache.invalidate_keys()
         keys = sorted(cache)
         assert keys == ['bar', 'baz', 'foo']
         assert 4 == store.counter['keys']
         assert 0 == store.counter['__contains__', 'foo']
         assert 0 == store.counter['__iter__']
-        cache.clear_keys()
+        cache.invalidate_keys()
         assert 'foo' in cache
         assert 5 == store.counter['keys']
         assert 0 == store.counter['__contains__', 'foo']

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -20,7 +20,7 @@ from zarr.storage import (init_array, array_meta_key, attrs_key, DictStore,
                           DirectoryStore, ZipStore, init_group, group_meta_key,
                           getsize, migrate_1to2, TempStore, atexit_rmtree,
                           NestedDirectoryStore, default_compressor, DBMStore,
-                          LMDBStore, atexit_rmglob)
+                          LMDBStore, atexit_rmglob, LRUStoreCache)
 from zarr.meta import (decode_array_metadata, encode_array_metadata, ZARR_FORMAT,
                        decode_group_metadata, encode_group_metadata)
 from zarr.compat import PY2
@@ -844,6 +844,14 @@ class TestLMDBStore(StoreTests, unittest.TestCase):
             store['foo'] = b'bar'
             store['baz'] = b'qux'
             eq(2, len(store))
+
+
+class TestLRUStoreCache(StoreTests, unittest.TestCase):
+
+    def create_store(self):
+        return LRUStoreCache(dict(), max_size=2**27)
+
+    # TODO test caching
 
 
 def test_getsize():

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+import collections
+
+
+class CountingDict(collections.MutableMapping):
+
+    def __init__(self):
+        self.wrapped = dict()
+        self.counter = collections.Counter()
+
+    def __len__(self):
+        return len(self.wrapped)
+
+    def __iter__(self):
+        return iter(self.wrapped)
+
+    def __contains__(self, item):
+        return item in self.wrapped
+
+    def __getitem__(self, item):
+        self.counter['__getitem__', item] += 1
+        return self.wrapped[item]
+
+    def __setitem__(self, key, value):
+        self.counter['__setitem__', key] += 1
+        self.wrapped[key] = value
+
+    def __delitem__(self, key):
+        self.counter['__delitem__', key] += 1
+        del self.wrapped[key]

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -10,12 +10,19 @@ class CountingDict(collections.MutableMapping):
         self.counter = collections.Counter()
 
     def __len__(self):
+        self.counter['__len__'] += 1
         return len(self.wrapped)
 
+    def keys(self):
+        self.counter['keys'] += 1
+        return self.wrapped.keys()
+
     def __iter__(self):
+        self.counter['__iter__'] += 1
         return iter(self.wrapped)
 
     def __contains__(self, item):
+        self.counter['__contains__', item] += 1
         return item in self.wrapped
 
     def __getitem__(self, item):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -318,7 +318,10 @@ def buffer_size(v):
         return v.buffer_info()[1] * v.itemsize
     else:  # pragma: py2 no cover
         v = memoryview(v)
-        return reduce(operator.mul, v.shape, 1) * v.itemsize
+        if v.shape:
+            return reduce(operator.mul, v.shape) * v.itemsize
+        else:
+            return v.itemsize
 
 
 def info_text_report(items):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -318,7 +318,7 @@ def buffer_size(v):
         return v.buffer_info()[1] * v.itemsize
     else:  # pragma: py2 no cover
         v = memoryview(v)
-        return reduce(operator.mul, v.shape) * v.itemsize
+        return reduce(operator.mul, v.shape, 1) * v.itemsize
 
 
 def info_text_report(items):


### PR DESCRIPTION
This PR adds a new ``zarr.storage.LRUStoreCache`` class which can be used as a cache layer for slow stores (e.g., stores accessed via network).

Also in developing this PR some inconsistencies in the way that ``zarr.storage.getsize()`` was implemented for different store types came to light and have been fixed.

TODO:
* [x] tests with max_size not None
* [x] test key caching
* [x] test coverage to 100%
* [x] API docs
* [x] document in tutorial
* [x] document changes  