### PR TITLE
Complete pytest migration

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -190,6 +190,7 @@ Maintenance
 
 * A data fixture has been included in the test suite to ensure data format
   compatibility is maintained; :issue:`83`, :issue:`146`.
+* The test suite has been migrated from nosetests to pytest; :issue:`189`, :issue:`225`.
 * Various continuous integration updates and improvements; :issue:`118`, :issue:`124`,
   :issue:`125`, :issue:`126`, :issue:`109`, :issue:`114`, :issue:`171`.
 

--- a/release.txt
+++ b/release.txt
@@ -1,4 +1,3 @@
-python setup.py build_ext --inplace
 tox
 # version=x.x.x
 echo $version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 asciitree
-nose
 pytest
 numpy
 fasteners

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,6 @@ idna==2.6
 mccabe==0.6.1
 monotonic==1.3
 msgpack-python==0.4.8
-nose==1.3.7
 numcodecs==0.5.2
 numpy==1.13.3
 packaging==16.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,6 +15,7 @@ idna==2.6
 mccabe==0.6.1
 monotonic==1.3
 msgpack-python==0.4.8
+nose==1.3.7
 numcodecs==0.5.2
 numpy==1.13.3
 packaging==16.8

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -113,11 +113,13 @@ class Attributes(MutableMapping):
         self._write_op(self._put_nosync, d)
 
     def _put_nosync(self, d):
-        s = json.dumps(d, indent=4, sort_keys=True, ensure_ascii=True, separators=(',', ': '))
+        s = json.dumps(d, indent=4, sort_keys=True, ensure_ascii=True,
+                       separators=(',', ': '))
         self.store[self.key] = s.encode('ascii')
         if self.cache:
             self._cached_asdict = d
 
+    # noinspection PyMethodOverriding
     def update(self, *args, **kwargs):
         """Update the values of several attributes in a single operation."""
         self._write_op(self._update_nosync, *args, **kwargs)

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -54,7 +54,7 @@ def open(store, mode='a', **kwargs):
         >>> zr = zarr.open(store, mode='r')  # open existing array read-only
         >>> zr
         <zarr.core.Array (100,) int32 read-only>
-        >>> gw = zarr.open(store, mode='w')  # open new group, overwriting any previous data
+        >>> gw = zarr.open(store, mode='w')  # open new group, overwriting previous data
         >>> gw
         <zarr.hierarchy.Group '/'>
         >>> ga = zarr.open(store, mode='a')  # open existing group for reading and writing
@@ -97,8 +97,8 @@ def open(store, mode='a', **kwargs):
 
 
 def save_array(store, arr, **kwargs):
-    """Convenience function to save a NumPy array to the local file system, following a similar
-    API to the NumPy save() function.
+    """Convenience function to save a NumPy array to the local file system, following a
+    similar API to the NumPy save() function.
 
     Parameters
     ----------
@@ -152,7 +152,8 @@ def save_group(store, *args, **kwargs):
 
     Examples
     --------
-    Save several arrays to a directory on the file system (uses a :class:`DirectoryStore`)::
+    Save several arrays to a directory on the file system (uses a
+    :class:`DirectoryStore`):
 
         >>> import zarr
         >>> import numpy as np
@@ -333,8 +334,9 @@ def load(store):
     Returns
     -------
     out
-        If the store contains an array, out will be a numpy array. If the store contains a group,
-        out will be a dict-like object where keys are array names and values are numpy arrays.
+        If the store contains an array, out will be a numpy array. If the store contains
+        a group, out will be a dict-like object where keys are array names and values
+        are numpy arrays.
 
     See Also
     --------
@@ -342,8 +344,8 @@ def load(store):
 
     Notes
     -----
-    If loading data from a group of arrays, data will not be immediately loaded into memory.
-    Rather, arrays will be loaded into memory as they are requested.
+    If loading data from a group of arrays, data will not be immediately loaded into
+    memory. Rather, arrays will be loaded into memory as they are requested.
 
     """
     # handle polymorphic store arg

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -80,13 +80,14 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     Create an array with different some different configuration options::
 
         >>> from numcodecs import Blosc
+        >>> compressor = Blosc(cname='zstd', clevel=1, shuffle=Blosc.BITSHUFFLE)
         >>> z = zarr.create((10000, 10000), chunks=(1000, 1000), dtype='i1', order='F',
-        ...                 compressor=Blosc(cname='zstd', clevel=1, shuffle=Blosc.BITSHUFFLE))
+        ...                 compressor=compressor)
         >>> z
         <zarr.core.Array (10000, 10000) int8>
 
-    To create an array with object dtype requires a filter that can handle Python object encoding,
-    e.g., `MsgPack` or `Pickle` from `numcodecs`::
+    To create an array with object dtype requires a filter that can handle Python object
+    encoding, e.g., `MsgPack` or `Pickle` from `numcodecs`::
 
         >>> from numcodecs import MsgPack
         >>> z = zarr.create((10000, 10000), chunks=(1000, 1000), dtype=object,

--- a/zarr/errors.py
+++ b/zarr/errors.py
@@ -61,6 +61,6 @@ def err_too_many_indices(selection, shape):
 
 
 def err_vindex_invalid_selection(selection):
-    raise IndexError('unsupported selection type for vectorized indexing; only coordinate '
-                     'selection (tuple of integer arrays) and mask selection (single '
-                     'Boolean array) are supported; got {!r}'.format(selection))
+    raise IndexError('unsupported selection type for vectorized indexing; only '
+                     'coordinate selection (tuple of integer arrays) and mask selection '
+                     '(single Boolean array) are supported; got {!r}'.format(selection))

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -708,6 +708,7 @@ class Group(MutableMapping):
         """Convenience method to require multiple groups in a single call."""
         return tuple(self.require_group(name) for name in names)
 
+    # noinspection PyIncorrectDocstring
     def create_dataset(self, name, **kwargs):
         """Create an array.
 
@@ -977,7 +978,8 @@ class Group(MutableMapping):
         dest = self._item_path(dest)
 
         # Check that source exists.
-        if not (contains_array(self._store, source) or contains_group(self._store, source)):
+        if not (contains_array(self._store, source) or
+                contains_group(self._store, source)):
             raise ValueError('The source, "%s", does not exist.' % source)
         if contains_array(self._store, dest) or contains_group(self._store, dest):
             raise ValueError('The dest, "%s", already exists.' % dest)

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -54,8 +54,10 @@ def normalize_integer_selection(dim_sel, dim_len):
     return dim_sel
 
 
-ChunkDimProjection = collections.namedtuple('ChunkDimProjection',
-                                            ('dim_chunk_ix', 'dim_chunk_sel', 'dim_out_sel'))
+ChunkDimProjection = collections.namedtuple(
+    'ChunkDimProjection',
+    ('dim_chunk_ix', 'dim_chunk_sel', 'dim_out_sel')
+)
 """A mapping from chunk to output array for a single dimension.
 
 Parameters
@@ -149,7 +151,8 @@ class SliceDimIndexer(object):
                 dim_chunk_sel_stop = self.stop - dim_offset
 
             dim_chunk_sel = slice(dim_chunk_sel_start, dim_chunk_sel_stop, self.step)
-            dim_chunk_nitems = ceildiv((dim_chunk_sel_stop - dim_chunk_sel_start), self.step)
+            dim_chunk_nitems = ceildiv((dim_chunk_sel_stop - dim_chunk_sel_start),
+                                       self.step)
             dim_out_sel = slice(dim_out_offset, dim_out_offset + dim_chunk_nitems)
 
             yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel)
@@ -211,11 +214,13 @@ def ensure_tuple(v):
     return v
 
 
-ChunkProjection = collections.namedtuple('ChunkProjection',
-                                         ('chunk_coords', 'chunk_selection', 'out_selection'))
-"""A mapping of items from chunk to output array. Can be used to extract items from the chunk
-array for loading into an output array. Can also be used to extract items from a value array for
-setting/updating in a chunk array.
+ChunkProjection = collections.namedtuple(
+    'ChunkProjection',
+    ('chunk_coords', 'chunk_selection', 'out_selection')
+)
+"""A mapping of items from chunk to output array. Can be used to extract items from the 
+chunk array for loading into an output array. Can also be used to extract items from a 
+value array for setting/updating in a chunk array.
 
 Parameters
 ----------
@@ -264,7 +269,8 @@ class BasicIndexer(object):
 
         # setup per-dimension indexers
         dim_indexers = []
-        for dim_sel, dim_len, dim_chunk_len in zip(selection, array._shape, array._chunks):
+        for dim_sel, dim_len, dim_chunk_len in \
+                zip(selection, array._shape, array._chunks):
 
             if is_integer(dim_sel):
                 dim_indexer = IntDimIndexer(dim_sel, dim_len, dim_chunk_len)
@@ -273,8 +279,9 @@ class BasicIndexer(object):
                 dim_indexer = SliceDimIndexer(dim_sel, dim_len, dim_chunk_len)
 
             else:
-                raise IndexError('unsupported selection item for basic indexing; expected integer '
-                                 'or slice, got {!r}'.format(type(dim_sel)))
+                raise IndexError('unsupported selection item for basic indexing; '
+                                 'expected integer or slice, got {!r}'
+                                 .format(type(dim_sel)))
 
             dim_indexers.append(dim_indexer)
 
@@ -300,7 +307,8 @@ class BoolArrayDimIndexer(object):
 
         # check number of dimensions
         if not is_bool_array(dim_sel, 1):
-            raise IndexError('Boolean arrays in an orthogonal selection must 1-dimensional only')
+            raise IndexError('Boolean arrays in an orthogonal selection must '
+                             'be 1-dimensional only')
 
         # check shape
         if dim_sel.shape[0] != dim_len:
@@ -392,7 +400,8 @@ class IntArrayDimIndexer(object):
         # ensure 1d array
         dim_sel = np.asanyarray(dim_sel)
         if not is_integer_array(dim_sel, 1):
-            raise IndexError('integer arrays in an orthogonal selection must be 1-dimensional only')
+            raise IndexError('integer arrays in an orthogonal selection must be '
+                             '1-dimensional only')
 
         # handle wraparound
         if wraparound:
@@ -409,7 +418,8 @@ class IntArrayDimIndexer(object):
         self.nitems = len(dim_sel)
 
         # determine which chunk is needed for each selection item
-        # note: for dense integer selections, the division operation here is the bottleneck
+        # note: for dense integer selections, the division operation here is the
+        # bottleneck
         dim_sel_chunk = dim_sel // dim_chunk_len
 
         # determine order of indices
@@ -520,7 +530,8 @@ class OrthogonalIndexer(object):
 
         # setup per-dimension indexers
         dim_indexers = []
-        for dim_sel, dim_len, dim_chunk_len in zip(selection, array._shape, array._chunks):
+        for dim_sel, dim_len, dim_chunk_len in \
+                zip(selection, array._shape, array._chunks):
 
             if is_integer(dim_sel):
                 dim_indexer = IntDimIndexer(dim_sel, dim_len, dim_chunk_len)
@@ -535,8 +546,9 @@ class OrthogonalIndexer(object):
                 dim_indexer = BoolArrayDimIndexer(dim_sel, dim_len, dim_chunk_len)
 
             else:
-                raise IndexError('unsupported selection item for orthogonal indexing; expected '
-                                 'integer, slice, integer array or Boolean array, got {!r}'
+                raise IndexError('unsupported selection item for orthogonal indexing; '
+                                 'expected integer, slice, integer array or Boolean '
+                                 'array, got {!r}'
                                  .format(type(dim_sel)))
 
             dim_indexers.append(dim_indexer)
@@ -563,9 +575,10 @@ class OrthogonalIndexer(object):
             # handle advanced indexing arrays orthogonally
             if self.is_advanced:
 
-                # numpy doesn't support orthogonal indexing directly as yet, so need to work
-                # around via np.ix_. Also np.ix_ does not support a mixture of arrays and slices
-                # or integers, so need to convert slices and integers into ranges.
+                # N.B., numpy doesn't support orthogonal indexing directly as yet,
+                # so need to work around via np.ix_. Also np.ix_ does not support a
+                # mixture of arrays and slices or integers, so need to convert slices
+                # and integers into ranges.
                 chunk_selection = ix_(chunk_selection, self.array._chunks)
 
                 # special case for non-monotonic indices
@@ -623,8 +636,9 @@ class CoordinateIndexer(object):
 
         # validation
         if not is_coordinate_selection(selection, array):
-            raise IndexError('invalid coordinate selection; expected one integer (coordinate) '
-                             'array per dimension of the target array, got {!r}'.format(selection))
+            raise IndexError('invalid coordinate selection; expected one integer '
+                             '(coordinate) array per dimension of the target array, '
+                             'got {!r}'.format(selection))
 
         # handle wraparound, boundscheck
         for dim_sel, dim_len in zip(selection, array.shape):
@@ -764,8 +778,8 @@ def check_fields(fields, dtype):
         return dtype
     # check type
     if not isinstance(fields, (str, list, tuple)):
-        raise IndexError("'fields' argument must be a string or list of strings; found {!r}"
-                         .format(type(fields)))
+        raise IndexError("'fields' argument must be a string or list of strings; found "
+                         "{!r}".format(type(fields)))
     if fields:
         if dtype.names is None:
             raise IndexError("invalid 'fields' argument, array does not have any fields")

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -218,8 +218,8 @@ ChunkProjection = collections.namedtuple(
     'ChunkProjection',
     ('chunk_coords', 'chunk_selection', 'out_selection')
 )
-"""A mapping of items from chunk to output array. Can be used to extract items from the 
-chunk array for loading into an output array. Can also be used to extract items from a 
+"""A mapping of items from chunk to output array. Can be used to extract items from the
+chunk array for loading into an output array. Can also be used to extract items from a
 value array for setting/updating in a chunk array.
 
 Parameters

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -139,6 +139,7 @@ def decode_fill_value(v, dtype):
         else:
             return np.array(v, dtype=dtype)[()]
     elif dtype.kind in 'SV':
+        # noinspection PyBroadException
         try:
             v = base64.standard_b64decode(v)
             v = np.array(v, dtype=dtype)[()]

--- a/zarr/tests/test_attrs.py
+++ b/zarr/tests/test_attrs.py
@@ -4,7 +4,7 @@ import json
 import unittest
 
 
-from nose.tools import eq_ as eq, assert_raises
+import pytest
 
 
 from zarr.attrs import Attributes
@@ -24,14 +24,14 @@ class TestAttributes(unittest.TestCase):
         a = Attributes(store=store, key='attrs')
         assert 'foo' not in a
         assert 'bar' not in a
-        eq(dict(), a.asdict())
+        assert dict() == a.asdict()
 
         a['foo'] = 'bar'
         a['baz'] = 42
         assert 'attrs' in store
         assert isinstance(store['attrs'], binary_type)
         d = json.loads(text_type(store['attrs'], 'ascii'))
-        eq(dict(foo='bar', baz=42), d)
+        assert dict(foo='bar', baz=42) == d
 
     def test_get_set_del_contains(self):
 
@@ -41,11 +41,11 @@ class TestAttributes(unittest.TestCase):
         a['baz'] = 42
         assert 'foo' in a
         assert 'baz' in a
-        eq('bar', a['foo'])
-        eq(42, a['baz'])
+        assert 'bar' == a['foo']
+        assert 42 == a['baz']
         del a['foo']
         assert 'foo' not in a
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             # noinspection PyStatementEffect
             a['foo']
 
@@ -57,44 +57,44 @@ class TestAttributes(unittest.TestCase):
         assert 'baz' not in a
 
         a.update(foo='spam', bar=42, baz=4.2)
-        eq(a['foo'], 'spam')
-        eq(a['bar'], 42)
-        eq(a['baz'], 4.2)
+        assert a['foo'] == 'spam'
+        assert a['bar'] == 42
+        assert a['baz'] == 4.2
 
         a.put(dict(foo='eggs', bar=84))
-        eq(a['foo'], 'eggs')
-        eq(a['bar'], 84)
+        assert a['foo'] == 'eggs'
+        assert a['bar'] == 84
         assert 'baz' not in a
 
     def test_iterators(self):
 
         a = self.init_attributes(dict())
-        eq(0, len(a))
-        eq(set(), set(a))
-        eq(set(), set(a.keys()))
-        eq(set(), set(a.values()))
-        eq(set(), set(a.items()))
+        assert 0 == len(a)
+        assert set() == set(a)
+        assert set() == set(a.keys())
+        assert set() == set(a.values())
+        assert set() == set(a.items())
 
         a['foo'] = 'bar'
         a['baz'] = 42
 
-        eq(2, len(a))
-        eq({'foo', 'baz'}, set(a))
-        eq({'foo', 'baz'}, set(a.keys()))
-        eq({'bar', 42}, set(a.values()))
-        eq({('foo', 'bar'), ('baz', 42)}, set(a.items()))
+        assert 2 == len(a)
+        assert {'foo', 'baz'} == set(a)
+        assert {'foo', 'baz'} == set(a.keys())
+        assert {'bar', 42} == set(a.values())
+        assert {('foo', 'bar'), ('baz', 42)} == set(a.items())
 
     def test_read_only(self):
         store = dict()
         a = self.init_attributes(store, read_only=True)
         store['attrs'] = json.dumps(dict(foo='bar', baz=42)).encode('ascii')
-        eq(a['foo'], 'bar')
-        eq(a['baz'], 42)
-        with assert_raises(PermissionError):
+        assert a['foo'] == 'bar'
+        assert a['baz'] == 42
+        with pytest.raises(PermissionError):
             a['foo'] = 'quux'
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             del a['foo']
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             a.update(foo='quux')
 
     def test_key_completions(self):
@@ -118,108 +118,108 @@ class TestAttributes(unittest.TestCase):
 
         # setup store
         store = CountingDict()
-        eq(0, store.counter['__getitem__', 'attrs'])
-        eq(0, store.counter['__setitem__', 'attrs'])
+        assert 0 == store.counter['__getitem__', 'attrs']
+        assert 0 == store.counter['__setitem__', 'attrs']
         store['attrs'] = json.dumps(dict(foo='xxx', bar=42)).encode('ascii')
-        eq(0, store.counter['__getitem__', 'attrs'])
-        eq(1, store.counter['__setitem__', 'attrs'])
+        assert 0 == store.counter['__getitem__', 'attrs']
+        assert 1 == store.counter['__setitem__', 'attrs']
 
         # setup attributes
         a = self.init_attributes(store)
 
         # test __getitem__ causes all attributes to be cached
-        eq(a['foo'], 'xxx')
-        eq(1, store.counter['__getitem__', 'attrs'])
-        eq(a['bar'], 42)
-        eq(1, store.counter['__getitem__', 'attrs'])
-        eq(a['foo'], 'xxx')
-        eq(1, store.counter['__getitem__', 'attrs'])
+        assert a['foo'] == 'xxx'
+        assert 1 == store.counter['__getitem__', 'attrs']
+        assert a['bar'] == 42
+        assert 1 == store.counter['__getitem__', 'attrs']
+        assert a['foo'] == 'xxx'
+        assert 1 == store.counter['__getitem__', 'attrs']
 
         # test __setitem__ updates the cache
         a['foo'] = 'yyy'
-        eq(2, store.counter['__getitem__', 'attrs'])
-        eq(2, store.counter['__setitem__', 'attrs'])
-        eq(a['foo'], 'yyy')
-        eq(2, store.counter['__getitem__', 'attrs'])
-        eq(2, store.counter['__setitem__', 'attrs'])
+        assert 2 == store.counter['__getitem__', 'attrs']
+        assert 2 == store.counter['__setitem__', 'attrs']
+        assert a['foo'] == 'yyy'
+        assert 2 == store.counter['__getitem__', 'attrs']
+        assert 2 == store.counter['__setitem__', 'attrs']
 
         # test update() updates the cache
         a.update(foo='zzz', bar=84)
-        eq(3, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
-        eq(a['foo'], 'zzz')
-        eq(a['bar'], 84)
-        eq(3, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
+        assert 3 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']
+        assert a['foo'] == 'zzz'
+        assert a['bar'] == 84
+        assert 3 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']
 
         # test __contains__ uses the cache
         assert 'foo' in a
-        eq(3, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
+        assert 3 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']
         assert 'spam' not in a
-        eq(3, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
+        assert 3 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']
 
         # test __delitem__ updates the cache
         del a['bar']
-        eq(4, store.counter['__getitem__', 'attrs'])
-        eq(4, store.counter['__setitem__', 'attrs'])
+        assert 4 == store.counter['__getitem__', 'attrs']
+        assert 4 == store.counter['__setitem__', 'attrs']
         assert 'bar' not in a
-        eq(4, store.counter['__getitem__', 'attrs'])
-        eq(4, store.counter['__setitem__', 'attrs'])
+        assert 4 == store.counter['__getitem__', 'attrs']
+        assert 4 == store.counter['__setitem__', 'attrs']
 
         # test refresh()
         store['attrs'] = json.dumps(dict(foo='xxx', bar=42)).encode('ascii')
-        eq(4, store.counter['__getitem__', 'attrs'])
+        assert 4 == store.counter['__getitem__', 'attrs']
         a.refresh()
-        eq(5, store.counter['__getitem__', 'attrs'])
-        eq(a['foo'], 'xxx')
-        eq(5, store.counter['__getitem__', 'attrs'])
-        eq(a['bar'], 42)
-        eq(5, store.counter['__getitem__', 'attrs'])
+        assert 5 == store.counter['__getitem__', 'attrs']
+        assert a['foo'] == 'xxx'
+        assert 5 == store.counter['__getitem__', 'attrs']
+        assert a['bar'] == 42
+        assert 5 == store.counter['__getitem__', 'attrs']
 
     def test_caching_off(self):
 
         # setup store
         store = CountingDict()
-        eq(0, store.counter['__getitem__', 'attrs'])
-        eq(0, store.counter['__setitem__', 'attrs'])
+        assert 0 == store.counter['__getitem__', 'attrs']
+        assert 0 == store.counter['__setitem__', 'attrs']
         store['attrs'] = json.dumps(dict(foo='xxx', bar=42)).encode('ascii')
-        eq(0, store.counter['__getitem__', 'attrs'])
-        eq(1, store.counter['__setitem__', 'attrs'])
+        assert 0 == store.counter['__getitem__', 'attrs']
+        assert 1 == store.counter['__setitem__', 'attrs']
 
         # setup attributes
         a = self.init_attributes(store, cache=False)
 
         # test __getitem__
-        eq(a['foo'], 'xxx')
-        eq(1, store.counter['__getitem__', 'attrs'])
-        eq(a['bar'], 42)
-        eq(2, store.counter['__getitem__', 'attrs'])
-        eq(a['foo'], 'xxx')
-        eq(3, store.counter['__getitem__', 'attrs'])
+        assert a['foo'] == 'xxx'
+        assert 1 == store.counter['__getitem__', 'attrs']
+        assert a['bar'] == 42
+        assert 2 == store.counter['__getitem__', 'attrs']
+        assert a['foo'] == 'xxx'
+        assert 3 == store.counter['__getitem__', 'attrs']
 
         # test __setitem__
         a['foo'] = 'yyy'
-        eq(4, store.counter['__getitem__', 'attrs'])
-        eq(2, store.counter['__setitem__', 'attrs'])
-        eq(a['foo'], 'yyy')
-        eq(5, store.counter['__getitem__', 'attrs'])
-        eq(2, store.counter['__setitem__', 'attrs'])
+        assert 4 == store.counter['__getitem__', 'attrs']
+        assert 2 == store.counter['__setitem__', 'attrs']
+        assert a['foo'] == 'yyy'
+        assert 5 == store.counter['__getitem__', 'attrs']
+        assert 2 == store.counter['__setitem__', 'attrs']
 
         # test update()
         a.update(foo='zzz', bar=84)
-        eq(6, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
-        eq(a['foo'], 'zzz')
-        eq(a['bar'], 84)
-        eq(8, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
+        assert 6 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']
+        assert a['foo'] == 'zzz'
+        assert a['bar'] == 84
+        assert 8 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']
 
         # test __contains__
         assert 'foo' in a
-        eq(9, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
+        assert 9 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']
         assert 'spam' not in a
-        eq(10, store.counter['__getitem__', 'attrs'])
-        eq(3, store.counter['__setitem__', 'attrs'])
+        assert 10 == store.counter['__getitem__', 'attrs']
+        assert 3 == store.counter['__setitem__', 'attrs']

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -6,7 +6,6 @@ import os
 import unittest
 
 
-from nose.tools import assert_raises
 import numpy as np
 from numpy.testing import assert_array_equal
 from numcodecs import Zlib, Adler32
@@ -42,7 +41,7 @@ def test_open_array():
     assert z.read_only
 
     # path not found
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         open('doesnotexist', mode='r')
 
 
@@ -69,10 +68,10 @@ def test_open_group():
 
 
 def test_save_errors():
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         # no arrays provided
         save_group('data/group.zarr')
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         # no arrays provided
         save('data/group.zarr')
 
@@ -427,7 +426,7 @@ class TestCopy(unittest.TestCase):
         assert not np.all(source['foo/bar/baz'][:] == dest['baz'][:])
 
         if self.dest_h5py:
-            with assert_raises(ValueError):
+            with pytest.raises(ValueError):
                 # not available with copy to h5py
                 copy(source['foo/bar/baz'], dest, if_exists='skip_initialized')
 
@@ -575,10 +574,9 @@ class TestCopy(unittest.TestCase):
 
 
 try:
-    import h5py  # no qa
-    have_h5py = True
+    import h5py
 except ImportError:  # pragma: no cover
-    have_h5py = False
+    h5py = None
 
 
 def temp_h5f():
@@ -589,7 +587,7 @@ def temp_h5f():
     return h5f
 
 
-@pytest.mark.skipif(not have_h5py, reason='h5py not installed')
+@pytest.mark.skipif(h5py is None, reason='h5py not installed')
 class TestCopyHDF5ToZarr(TestCopy):
 
     def __init__(self, *args, **kwargs):
@@ -600,7 +598,7 @@ class TestCopyHDF5ToZarr(TestCopy):
         self.new_dest = group
 
 
-@pytest.mark.skipif(not have_h5py, reason='h5py not installed')
+@pytest.mark.skipif(h5py is None, reason='h5py not installed')
 class TestCopyZarrToHDF5(TestCopy):
 
     def __init__(self, *args, **kwargs):
@@ -611,7 +609,7 @@ class TestCopyZarrToHDF5(TestCopy):
         self.new_dest = temp_h5f
 
 
-@pytest.mark.skipif(not have_h5py, reason='h5py not installed')
+@pytest.mark.skipif(h5py is None, reason='h5py not installed')
 class TestCopyHDF5ToHDF5(TestCopy):
 
     def __init__(self, *args, **kwargs):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1272,7 +1272,7 @@ class TestArrayWithDBMStoreBerkeleyDB(TestArray):
 
 try:
     import lmdb
-except ImportError:
+except ImportError:  # pragma: no cover
     lmdb = None
 
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -11,9 +11,6 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import (eq_ as eq, assert_is_instance, assert_raises, assert_true,
-                        assert_false, assert_is, assert_is_none)
-from nose import SkipTest
 import pytest
 
 
@@ -44,37 +41,37 @@ class TestArray(unittest.TestCase):
         store = dict()
         init_array(store, shape=100, chunks=10)
         a = Array(store)
-        assert_is_instance(a, Array)
-        eq((100,), a.shape)
-        eq((10,), a.chunks)
-        eq('', a.path)
-        assert_is_none(a.name)
-        assert_is_none(a.basename)
-        assert_is(store, a.store)
-        eq("8fecb7a17ea1493d9c1430d04437b4f5b0b34985", a.hexdigest())
+        assert isinstance(a, Array)
+        assert (100,) == a.shape
+        assert (10,) == a.chunks
+        assert '' == a.path
+        assert a.name is None
+        assert a.basename is None
+        assert store is a.store
+        assert "8fecb7a17ea1493d9c1430d04437b4f5b0b34985" == a.hexdigest()
 
         # initialize at path
         store = dict()
         init_array(store, shape=100, chunks=10, path='foo/bar')
         a = Array(store, path='foo/bar')
-        assert_is_instance(a, Array)
-        eq((100,), a.shape)
-        eq((10,), a.chunks)
-        eq('foo/bar', a.path)
-        eq('/foo/bar', a.name)
-        eq('bar', a.basename)
-        assert_is(store, a.store)
-        eq("8fecb7a17ea1493d9c1430d04437b4f5b0b34985", a.hexdigest())
+        assert isinstance(a, Array)
+        assert (100,) == a.shape
+        assert (10,) == a.chunks
+        assert 'foo/bar' == a.path
+        assert '/foo/bar' == a.name
+        assert 'bar' == a.basename
+        assert store is a.store
+        assert "8fecb7a17ea1493d9c1430d04437b4f5b0b34985" == a.hexdigest()
 
         # store not initialized
         store = dict()
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             Array(store)
 
         # group is in the way
         store = dict()
         init_group(store, path='baz')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             Array(store, path='baz')
 
     def create_array(self, read_only=False, **kwargs):
@@ -91,15 +88,15 @@ class TestArray(unittest.TestCase):
         # dict as store
         z = self.create_array(shape=1000, chunks=100)
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
         z[:] = 42
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
 
         # mess with store
         try:
             z.store[z._key_prefix + 'foo'] = list(range(10))
-            eq(-1, z.nbytes_stored)
+            assert -1 == z.nbytes_stored
         except TypeError:
             pass
 
@@ -109,33 +106,33 @@ class TestArray(unittest.TestCase):
         z = self.create_array(shape=a.shape, chunks=100, dtype=a.dtype)
 
         # check properties
-        eq(len(a), len(z))
-        eq(a.ndim, z.ndim)
-        eq(a.shape, z.shape)
-        eq(a.dtype, z.dtype)
-        eq((100,), z.chunks)
-        eq(a.nbytes, z.nbytes)
-        eq(11, z.nchunks)
-        eq(0, z.nchunks_initialized)
-        eq((11,), z.cdata_shape)
+        assert len(a) == len(z)
+        assert a.ndim == z.ndim
+        assert a.shape == z.shape
+        assert a.dtype == z.dtype
+        assert (100,) == z.chunks
+        assert a.nbytes == z.nbytes
+        assert 11 == z.nchunks
+        assert 0 == z.nchunks_initialized
+        assert (11,) == z.cdata_shape
 
         # check empty
         b = z[:]
-        assert_is_instance(b, np.ndarray)
-        eq(a.shape, b.shape)
-        eq(a.dtype, b.dtype)
+        assert isinstance(b, np.ndarray)
+        assert a.shape == b.shape
+        assert a.dtype == b.dtype
 
         # check attributes
         z.attrs['foo'] = 'bar'
-        eq('bar', z.attrs['foo'])
+        assert 'bar' == z.attrs['foo']
 
         # set data
         z[:] = a
 
         # check properties
-        eq(a.nbytes, z.nbytes)
-        eq(11, z.nchunks)
-        eq(11, z.nchunks_initialized)
+        assert a.nbytes == z.nbytes
+        assert 11 == z.nchunks
+        assert 11 == z.nchunks_initialized
 
         # check slicing
         assert_array_equal(a, np.array(z))
@@ -157,24 +154,24 @@ class TestArray(unittest.TestCase):
         assert_array_equal(a[190:310], z[190:310])
         assert_array_equal(a[-110:], z[-110:])
         # single item
-        eq(a[0], z[0])
-        eq(a[-1], z[-1])
+        assert a[0] == z[0]
+        assert a[-1] == z[-1]
         # unusual integer items
-        eq(a[42], z[np.int64(42)])
-        eq(a[42], z[np.int32(42)])
-        eq(a[42], z[np.uint64(42)])
-        eq(a[42], z[np.uint32(42)])
+        assert a[42] == z[np.int64(42)]
+        assert a[42] == z[np.int32(42)]
+        assert a[42] == z[np.uint64(42)]
+        assert a[42] == z[np.uint32(42)]
         # too many indices
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:, :]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[0, :]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:, 0]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[0, 0]
         # only single ellipsis allowed
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[..., ...]
 
         # check partial assignment
@@ -263,20 +260,20 @@ class TestArray(unittest.TestCase):
         z = self.create_array(shape=a.shape, chunks=(100, 2), dtype=a.dtype)
 
         # check properties
-        eq(len(a), len(z))
-        eq(a.ndim, z.ndim)
-        eq(a.shape, z.shape)
-        eq(a.dtype, z.dtype)
-        eq((100, 2), z.chunks)
-        eq(0, z.nchunks_initialized)
-        eq((10, 5), z.cdata_shape)
+        assert len(a) == len(z)
+        assert a.ndim == z.ndim
+        assert a.shape == z.shape
+        assert a.dtype == z.dtype
+        assert (100, 2) == z.chunks
+        assert 0 == z.nchunks_initialized
+        assert (10, 5) == z.cdata_shape
 
         # set data
         z[:] = a
 
         # check properties
-        eq(a.nbytes, z.nbytes)
-        eq(50, z.nchunks_initialized)
+        assert a.nbytes == z.nbytes
+        assert 50 == z.nchunks_initialized
 
         # check array-like
         assert_array_equal(a, np.array(z))
@@ -338,22 +335,22 @@ class TestArray(unittest.TestCase):
         assert_array_equal(a[-1], z[-1])
         assert_array_equal(a[:, 0], z[:, 0])
         assert_array_equal(a[:, -1], z[:, -1])
-        eq(a[0, 0], z[0, 0])
-        eq(a[-1, -1], z[-1, -1])
+        assert a[0, 0] == z[0, 0]
+        assert a[-1, -1] == z[-1, -1]
 
         # too many indices
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:, :, :]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[0, :, :]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:, 0, :]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:, :, 0]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[0, 0, 0]
         # only single ellipsis allowed
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[..., ...]
 
         # check partial assignment
@@ -384,10 +381,10 @@ class TestArray(unittest.TestCase):
         # check partial assignment, single row
         c = np.arange(z.shape[1])
         z[0, :] = c
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             # N.B., NumPy allows this, but we'll be strict for now
             z[2:3] = c
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             # N.B., NumPy allows this, but we'll be strict for now
             z[-1:] = c
         z[2:3] = c[None, :]
@@ -399,9 +396,9 @@ class TestArray(unittest.TestCase):
         # check partial assignment, single column
         d = np.arange(z.shape[0])
         z[:, 0] = d
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             z[:, 2:3] = d
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             z[:, -1:] = d
         z[:, 2:3] = d[:, None]
         z[:, -1:] = d[:, None]
@@ -413,9 +410,9 @@ class TestArray(unittest.TestCase):
         z[0, 0] = -1
         z[2, 2] = -1
         z[-1, -1] = -1
-        eq(-1, z[0, 0])
-        eq(-1, z[2, 2])
-        eq(-1, z[-1, -1])
+        assert -1 == z[0, 0]
+        assert -1 == z[2, 2]
+        assert -1 == z[-1, -1]
 
     def test_array_order(self):
 
@@ -424,11 +421,11 @@ class TestArray(unittest.TestCase):
         for order in 'C', 'F':
             z = self.create_array(shape=a.shape, chunks=100, dtype=a.dtype,
                                   order=order)
-            eq(order, z.order)
+            assert order == z.order
             if order == 'F':
-                assert_true(z[:].flags.f_contiguous)
+                assert z[:].flags.f_contiguous
             else:
-                assert_true(z[:].flags.c_contiguous)
+                assert z[:].flags.c_contiguous
             z[:] = a
             assert_array_equal(a, z[:])
 
@@ -437,11 +434,11 @@ class TestArray(unittest.TestCase):
         for order in 'C', 'F':
             z = self.create_array(shape=a.shape, chunks=(10, 10),
                                   dtype=a.dtype, order=order)
-            eq(order, z.order)
+            assert order == z.order
             if order == 'F':
-                assert_true(z[:].flags.f_contiguous)
+                assert z[:].flags.f_contiguous
             else:
-                assert_true(z[:].flags.c_contiguous)
+                assert z[:].flags.c_contiguous
             z[:] = a
             actual = z[:]
             assert_array_equal(a, actual)
@@ -459,25 +456,25 @@ class TestArray(unittest.TestCase):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('063b02ff8d9d3bab6da932ad5828b506ef0a6578', z.hexdigest())
+        assert '063b02ff8d9d3bab6da932ad5828b506ef0a6578' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('f97b84dc9ffac807415f750100108764e837bb82', z.hexdigest())
+        assert 'f97b84dc9ffac807415f750100108764e837bb82' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('4f797d7bdad0fa1c9fa8c80832efb891a68de104', z.hexdigest())
+        assert '4f797d7bdad0fa1c9fa8c80832efb891a68de104' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('14470724dca6c1837edddedc490571b6a7f270bc', z.hexdigest())
+        assert '14470724dca6c1837edddedc490571b6a7f270bc' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('2a1046dd99b914459b3e86be9dde05027a07d209', z.hexdigest())
+        assert '2a1046dd99b914459b3e86be9dde05027a07d209' == z.hexdigest()
 
     def test_resize_1d(self):
 
@@ -485,34 +482,34 @@ class TestArray(unittest.TestCase):
                               fill_value=0)
         a = np.arange(105, dtype='i4')
         z[:] = a
-        eq((105,), z.shape)
-        eq((105,), z[:].shape)
-        eq(np.dtype('i4'), z.dtype)
-        eq(np.dtype('i4'), z[:].dtype)
-        eq((10,), z.chunks)
+        assert (105,) == z.shape
+        assert (105,) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10,) == z.chunks
         assert_array_equal(a, z[:])
 
         z.resize(205)
-        eq((205,), z.shape)
-        eq((205,), z[:].shape)
-        eq(np.dtype('i4'), z.dtype)
-        eq(np.dtype('i4'), z[:].dtype)
-        eq((10,), z.chunks)
+        assert (205,) == z.shape
+        assert (205,) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10,) == z.chunks
         assert_array_equal(a, z[:105])
         assert_array_equal(np.zeros(100, dtype='i4'), z[105:])
 
         z.resize(55)
-        eq((55,), z.shape)
-        eq((55,), z[:].shape)
-        eq(np.dtype('i4'), z.dtype)
-        eq(np.dtype('i4'), z[:].dtype)
-        eq((10,), z.chunks)
+        assert (55,) == z.shape
+        assert (55,) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10,) == z.chunks
         assert_array_equal(a[:55], z[:])
 
         # via shape setter
         z.shape = (105,)
-        eq((105,), z.shape)
-        eq((105,), z[:].shape)
+        assert (105,) == z.shape
+        assert (105,) == z[:].shape
 
     def test_resize_2d(self):
 
@@ -520,69 +517,69 @@ class TestArray(unittest.TestCase):
                               fill_value=0)
         a = np.arange(105*105, dtype='i4').reshape((105, 105))
         z[:] = a
-        eq((105, 105), z.shape)
-        eq((105, 105), z[:].shape)
-        eq(np.dtype('i4'), z.dtype)
-        eq(np.dtype('i4'), z[:].dtype)
-        eq((10, 10), z.chunks)
+        assert (105, 105) == z.shape
+        assert (105, 105) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10, 10) == z.chunks
         assert_array_equal(a, z[:])
 
         z.resize((205, 205))
-        eq((205, 205), z.shape)
-        eq((205, 205), z[:].shape)
-        eq(np.dtype('i4'), z.dtype)
-        eq(np.dtype('i4'), z[:].dtype)
-        eq((10, 10), z.chunks)
+        assert (205, 205) == z.shape
+        assert (205, 205) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10, 10) == z.chunks
         assert_array_equal(a, z[:105, :105])
         assert_array_equal(np.zeros((100, 205), dtype='i4'), z[105:, :])
         assert_array_equal(np.zeros((205, 100), dtype='i4'), z[:, 105:])
 
         z.resize((55, 55))
-        eq((55, 55), z.shape)
-        eq((55, 55), z[:].shape)
-        eq(np.dtype('i4'), z.dtype)
-        eq(np.dtype('i4'), z[:].dtype)
-        eq((10, 10), z.chunks)
+        assert (55, 55) == z.shape
+        assert (55, 55) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10, 10) == z.chunks
         assert_array_equal(a[:55, :55], z[:])
 
         z.resize((55, 1))
-        eq((55, 1), z.shape)
-        eq((55, 1), z[:].shape)
-        eq(np.dtype('i4'), z.dtype)
-        eq(np.dtype('i4'), z[:].dtype)
-        eq((10, 10), z.chunks)
+        assert (55, 1) == z.shape
+        assert (55, 1) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10, 10) == z.chunks
         assert_array_equal(a[:55, :1], z[:])
 
         # via shape setter
         z.shape = (105, 105)
-        eq((105, 105), z.shape)
-        eq((105, 105), z[:].shape)
+        assert (105, 105) == z.shape
+        assert (105, 105) == z[:].shape
 
     def test_append_1d(self):
 
         a = np.arange(105)
         z = self.create_array(shape=a.shape, chunks=10, dtype=a.dtype)
         z[:] = a
-        eq(a.shape, z.shape)
-        eq(a.dtype, z.dtype)
-        eq((10,), z.chunks)
+        assert a.shape == z.shape
+        assert a.dtype == z.dtype
+        assert (10,) == z.chunks
         assert_array_equal(a, z[:])
 
         b = np.arange(105, 205)
         e = np.append(a, b)
         z.append(b)
-        eq(e.shape, z.shape)
-        eq(e.dtype, z.dtype)
-        eq((10,), z.chunks)
+        assert e.shape == z.shape
+        assert e.dtype == z.dtype
+        assert (10,) == z.chunks
         assert_array_equal(e, z[:])
 
         # check append handles array-like
         c = [1, 2, 3]
         f = np.append(e, c)
         z.append(c)
-        eq(f.shape, z.shape)
-        eq(f.dtype, z.dtype)
-        eq((10,), z.chunks)
+        assert f.shape == z.shape
+        assert f.dtype == z.dtype
+        assert (10,) == z.chunks
         assert_array_equal(f, z[:])
 
     def test_append_2d(self):
@@ -590,18 +587,18 @@ class TestArray(unittest.TestCase):
         a = np.arange(105*105, dtype='i4').reshape((105, 105))
         z = self.create_array(shape=a.shape, chunks=(10, 10), dtype=a.dtype)
         z[:] = a
-        eq(a.shape, z.shape)
-        eq(a.dtype, z.dtype)
-        eq((10, 10), z.chunks)
+        assert a.shape == z.shape
+        assert a.dtype == z.dtype
+        assert (10, 10) == z.chunks
         actual = z[:]
         assert_array_equal(a, actual)
 
         b = np.arange(105*105, 2*105*105, dtype='i4').reshape((105, 105))
         e = np.append(a, b, axis=0)
         z.append(b)
-        eq(e.shape, z.shape)
-        eq(e.dtype, z.dtype)
-        eq((10, 10), z.chunks)
+        assert e.shape == z.shape
+        assert e.dtype == z.dtype
+        assert (10, 10) == z.chunks
         actual = z[:]
         assert_array_equal(e, actual)
 
@@ -610,17 +607,17 @@ class TestArray(unittest.TestCase):
         a = np.arange(105*105, dtype='i4').reshape((105, 105))
         z = self.create_array(shape=a.shape, chunks=(10, 10), dtype=a.dtype)
         z[:] = a
-        eq(a.shape, z.shape)
-        eq(a.dtype, z.dtype)
-        eq((10, 10), z.chunks)
+        assert a.shape == z.shape
+        assert a.dtype == z.dtype
+        assert (10, 10) == z.chunks
         assert_array_equal(a, z[:])
 
         b = np.arange(105*105, 2*105*105, dtype='i4').reshape((105, 105))
         e = np.append(a, b, axis=1)
         z.append(b, axis=1)
-        eq(e.shape, z.shape)
-        eq(e.dtype, z.dtype)
-        eq((10, 10), z.chunks)
+        assert e.shape == z.shape
+        assert e.dtype == z.dtype
+        assert (10, 10) == z.chunks
         assert_array_equal(e, z[:])
 
     def test_append_bad_shape(self):
@@ -628,33 +625,33 @@ class TestArray(unittest.TestCase):
         z = self.create_array(shape=a.shape, chunks=10, dtype=a.dtype)
         z[:] = a
         b = a.reshape(10, 10)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             z.append(b)
 
     def test_read_only(self):
 
         z = self.create_array(shape=1000, chunks=100)
-        assert_false(z.read_only)
+        assert not z.read_only
 
         z = self.create_array(shape=1000, chunks=100, read_only=True)
-        assert_true(z.read_only)
-        with assert_raises(PermissionError):
+        assert z.read_only
+        with pytest.raises(PermissionError):
             z[:] = 42
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.resize(2000)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.append(np.arange(1000))
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.set_basic_selection(Ellipsis, 42)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.set_orthogonal_selection([0, 1, 2], 42)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.oindex[[0, 1, 2]] = 42
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.set_coordinate_selection([0, 1, 2], 42)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.vindex[[0, 1, 2]] = 42
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             z.set_mask_selection(np.ones(z.shape, dtype=bool), 42)
 
     def test_pickle(self):
@@ -663,14 +660,14 @@ class TestArray(unittest.TestCase):
                               cache_attrs=False)
         z[:] = np.random.randint(0, 1000, 1000)
         z2 = pickle.loads(pickle.dumps(z))
-        eq(z.shape, z2.shape)
-        eq(z.chunks, z2.chunks)
-        eq(z.dtype, z2.dtype)
+        assert z.shape == z2.shape
+        assert z.chunks == z2.chunks
+        assert z.dtype == z2.dtype
         if z.compressor:
-            eq(z.compressor.get_config(), z2.compressor.get_config())
-        eq(z.fill_value, z2.fill_value)
-        eq(z._cache_metadata, z2._cache_metadata)
-        eq(z.attrs.cache, z2.attrs.cache)
+            assert z.compressor.get_config() == z2.compressor.get_config()
+        assert z.fill_value == z2.fill_value
+        assert z._cache_metadata == z2._cache_metadata
+        assert z.attrs.cache == z2.attrs.cache
         assert_array_equal(z[:], z2[:])
 
     def test_np_ufuncs(self):
@@ -678,9 +675,9 @@ class TestArray(unittest.TestCase):
         a = np.arange(10000).reshape(100, 100)
         z[:] = a
 
-        eq(np.sum(a), np.sum(z))
+        assert np.sum(a) == np.sum(z)
         assert_array_equal(np.sum(a, axis=0), np.sum(z, axis=0))
-        eq(np.mean(a), np.mean(z))
+        assert np.mean(a) == np.mean(z)
         assert_array_equal(np.mean(a, axis=1), np.mean(z, axis=1))
         condition = np.random.randint(0, 2, size=100, dtype=bool)
         assert_array_equal(np.compress(condition, a, axis=0),
@@ -708,23 +705,23 @@ class TestArray(unittest.TestCase):
 
         z = self.create_array(shape=0, fill_value=0)
         a = np.zeros(0)
-        eq(a.ndim, z.ndim)
-        eq(a.shape, z.shape)
-        eq(a.dtype, z.dtype)
-        eq(a.size, z.size)
-        eq(0, z.nchunks)
+        assert a.ndim == z.ndim
+        assert a.shape == z.shape
+        assert a.dtype == z.dtype
+        assert a.size == z.size
+        assert 0 == z.nchunks
 
         # cannot make a good decision when auto-chunking if a dimension has zero length,
         # fall back to 1 for now
-        eq((1,), z.chunks)
+        assert (1,) == z.chunks
 
         # check __getitem__
-        assert_is_instance(z[:], np.ndarray)
+        assert isinstance(z[:], np.ndarray)
         assert_array_equal(a, np.array(z))
         assert_array_equal(a, z[:])
         assert_array_equal(a, z[...])
         assert_array_equal(a[0:0], z[0:0])
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[0]
 
         # check __setitem__
@@ -732,7 +729,7 @@ class TestArray(unittest.TestCase):
         z[:] = 42
         z[...] = 42
         # this should error
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[0] = 42
 
     # noinspection PyStatementEffect
@@ -741,18 +738,18 @@ class TestArray(unittest.TestCase):
 
         z = self.create_array(shape=(10, 0), fill_value=0)
         a = np.zeros((10, 0))
-        eq(a.ndim, z.ndim)
-        eq(a.shape, z.shape)
-        eq(a.dtype, z.dtype)
-        eq(a.size, z.size)
-        eq(0, z.nchunks)
+        assert a.ndim == z.ndim
+        assert a.shape == z.shape
+        assert a.dtype == z.dtype
+        assert a.size == z.size
+        assert 0 == z.nchunks
 
         # cannot make a good decision when auto-chunking if a dimension has zero length,
         # fall back to 1 for now
-        eq((10, 1), z.chunks)
+        assert (10, 1) == z.chunks
 
         # check __getitem__
-        assert_is_instance(z[:], np.ndarray)
+        assert isinstance(z[:], np.ndarray)
         assert_array_equal(a, np.array(z))
         assert_array_equal(a, z[:])
         assert_array_equal(a, z[...])
@@ -760,7 +757,7 @@ class TestArray(unittest.TestCase):
         assert_array_equal(a[0, 0:0], z[0, 0:0])
         assert_array_equal(a[0, :], z[0, :])
         assert_array_equal(a[0, 0:0], z[0, 0:0])
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:, 0]
 
         # check __setitem__
@@ -769,7 +766,7 @@ class TestArray(unittest.TestCase):
         z[...] = 42
         z[0, :] = 42
         # this should error
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:, 0] = 42
 
     # noinspection PyStatementEffect
@@ -781,53 +778,53 @@ class TestArray(unittest.TestCase):
         z = self.create_array(shape=(), dtype=a.dtype, fill_value=0)
 
         # check properties
-        eq(a.ndim, z.ndim)
-        eq(a.shape, z.shape)
-        eq(a.size, z.size)
-        eq(a.dtype, z.dtype)
-        eq(a.nbytes, z.nbytes)
-        with assert_raises(TypeError):
+        assert a.ndim == z.ndim
+        assert a.shape == z.shape
+        assert a.size == z.size
+        assert a.dtype == z.dtype
+        assert a.nbytes == z.nbytes
+        with pytest.raises(TypeError):
             len(z)
-        eq((), z.chunks)
-        eq(1, z.nchunks)
-        eq((1,), z.cdata_shape)
+        assert () == z.chunks
+        assert 1 == z.nchunks
+        assert (1,) == z.cdata_shape
         # compressor always None - no point in compressing a single value
-        assert_is_none(z.compressor)
+        assert z.compressor is None
 
         # check __getitem__
         b = z[...]
-        assert_is_instance(b, np.ndarray)
-        eq(a.shape, b.shape)
-        eq(a.dtype, b.dtype)
+        assert isinstance(b, np.ndarray)
+        assert a.shape == b.shape
+        assert a.dtype == b.dtype
         assert_array_equal(a, np.array(z))
         assert_array_equal(a, z[...])
-        eq(a[()], z[()])
-        with assert_raises(IndexError):
+        assert a[()] == z[()]
+        with pytest.raises(IndexError):
             z[0]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:]
 
         # check __setitem__
         z[...] = 42
-        eq(42, z[()])
+        assert 42 == z[()]
         z[()] = 43
-        eq(43, z[()])
-        with assert_raises(IndexError):
+        assert 43 == z[()]
+        with pytest.raises(IndexError):
             z[0] = 42
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[:] = 42
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             z[...] = np.array([1, 2, 3])
 
     def test_nchunks_initialized(self):
 
         z = self.create_array(shape=100, chunks=10)
-        eq(0, z.nchunks_initialized)
+        assert 0 == z.nchunks_initialized
         # manually put something into the store to confuse matters
         z.store['foo'] = b'bar'
-        eq(0, z.nchunks_initialized)
+        assert 0 == z.nchunks_initialized
         z[:] = 42
-        eq(10, z.nchunks_initialized)
+        assert 10 == z.nchunks_initialized
 
     def test_structured_array(self):
 
@@ -840,24 +837,24 @@ class TestArray(unittest.TestCase):
             for fill_value in None, b'', (b'zzz', 0, 0.0):
                 z = self.create_array(shape=a.shape, chunks=2, dtype=a.dtype,
                                       fill_value=fill_value)
-                eq(len(a), len(z))
+                assert len(a) == len(z)
                 if fill_value is not None:
                     np_fill_value = np.array(fill_value, dtype=a.dtype)[()]
-                    eq(np_fill_value, z.fill_value)
+                    assert np_fill_value == z.fill_value
                     if len(z):
-                        eq(np_fill_value, z[0])
-                        eq(np_fill_value, z[-1])
+                        assert np_fill_value == z[0]
+                        assert np_fill_value == z[-1]
                 z[...] = a
                 if len(a):
-                    eq(a[0], z[0])
+                    assert a[0] == z[0]
                 assert_array_equal(a, z[...])
                 assert_array_equal(a['foo'], z['foo'])
                 assert_array_equal(a['bar'], z['bar'])
                 assert_array_equal(a['baz'], z['baz'])
 
-        with assert_raises(ValueError):
-            # dodgy fill value
-            self.create_array(shape=a.shape, chunks=2, dtype=a.dtype, fill_value=42)
+            with pytest.raises(ValueError):
+                # dodgy fill value
+                self.create_array(shape=a.shape, chunks=2, dtype=a.dtype, fill_value=42)
 
     def test_dtypes(self):
 
@@ -889,9 +886,9 @@ class TestArray(unittest.TestCase):
                 assert_array_equal(a, z[:])
 
         # check that datetime generic units are not allowed
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             self.create_array(shape=100, dtype='M8')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             self.create_array(shape=100, dtype='m8')
 
     def test_object_arrays(self):
@@ -1028,10 +1025,10 @@ class TestArray(unittest.TestCase):
             assert isinstance(actual, np.ndarray)
             assert actual.dtype == object
             assert actual.shape == expected.shape
-            for e, a in zip(expected.flat, actual.flat):
-                assert isinstance(a, np.ndarray)
-                assert_array_equal(e, a)
-                assert a.dtype == item_dtype
+            for ev, av in zip(expected.flat, actual.flat):
+                assert isinstance(av, np.ndarray)
+                assert_array_equal(ev, av)
+                assert av.dtype == item_dtype
 
         codecs = VLenArray(int), VLenArray('<u4')
         for codec in codecs:
@@ -1058,9 +1055,9 @@ class TestArray(unittest.TestCase):
         z = self.create_array(shape=5, chunks=2, dtype=object, fill_value=0,
                               object_codec=MsgPack())
         z._filters = None  # wipe filters
-        with assert_raises(RuntimeError):
+        with pytest.raises(RuntimeError):
             z[0] = 'foo'
-        with assert_raises(RuntimeError):
+        with pytest.raises(RuntimeError):
             z[:] = 42
 
         # do something else dangerous
@@ -1072,7 +1069,7 @@ class TestArray(unittest.TestCase):
                                   compressor=compressor)
             z[:] = data
             v = z.view(filters=[])
-            with assert_raises(RuntimeError):
+            with pytest.raises(RuntimeError):
                 # noinspection PyStatementEffect
                 v[:]
 
@@ -1097,25 +1094,25 @@ class TestArrayWithPath(TestArray):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('f710da18d45d38d4aaf2afd7fb822fdd73d02957', z.hexdigest())
+        assert 'f710da18d45d38d4aaf2afd7fb822fdd73d02957' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('1437428e69754b1e1a38bd7fc9e43669577620db', z.hexdigest())
+        assert '1437428e69754b1e1a38bd7fc9e43669577620db' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('dde44c72cc530bd6aae39b629eb15a2da627e5f9', z.hexdigest())
+        assert 'dde44c72cc530bd6aae39b629eb15a2da627e5f9' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('4c0a76fb1222498e09dcd92f7f9221d6cea8b40e', z.hexdigest())
+        assert '4c0a76fb1222498e09dcd92f7f9221d6cea8b40e' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('05b0663ffe1785f38d3a459dec17e57a18f254af', z.hexdigest())
+        assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
 
     def test_nbytes_stored(self):
 
@@ -1124,16 +1121,16 @@ class TestArrayWithPath(TestArray):
         expect_nbytes_stored = sum(buffer_size(v)
                                    for k, v in z.store.items()
                                    if k.startswith('foo/bar/'))
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
         z[:] = 42
         expect_nbytes_stored = sum(buffer_size(v)
                                    for k, v in z.store.items()
                                    if k.startswith('foo/bar/'))
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
 
         # mess with store
         z.store[z._key_prefix + 'foo'] = list(range(10))
-        eq(-1, z.nbytes_stored)
+        assert -1 == z.nbytes_stored
 
 
 class TestArrayWithChunkStore(TestArray):
@@ -1152,25 +1149,25 @@ class TestArrayWithChunkStore(TestArray):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('f710da18d45d38d4aaf2afd7fb822fdd73d02957', z.hexdigest())
+        assert 'f710da18d45d38d4aaf2afd7fb822fdd73d02957' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('1437428e69754b1e1a38bd7fc9e43669577620db', z.hexdigest())
+        assert '1437428e69754b1e1a38bd7fc9e43669577620db' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('dde44c72cc530bd6aae39b629eb15a2da627e5f9', z.hexdigest())
+        assert 'dde44c72cc530bd6aae39b629eb15a2da627e5f9' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('4c0a76fb1222498e09dcd92f7f9221d6cea8b40e', z.hexdigest())
+        assert '4c0a76fb1222498e09dcd92f7f9221d6cea8b40e' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('05b0663ffe1785f38d3a459dec17e57a18f254af', z.hexdigest())
+        assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
 
     def test_nbytes_stored(self):
 
@@ -1178,16 +1175,16 @@ class TestArrayWithChunkStore(TestArray):
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         expect_nbytes_stored += sum(buffer_size(v)
                                     for v in z.chunk_store.values())
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
         z[:] = 42
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         expect_nbytes_stored += sum(buffer_size(v)
                                     for v in z.chunk_store.values())
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
 
         # mess with store
         z.chunk_store[z._key_prefix + 'foo'] = list(range(10))
-        eq(-1, z.nbytes_stored)
+        assert -1 == z.nbytes_stored
 
 
 class TestArrayWithDirectoryStore(TestArray):
@@ -1209,10 +1206,10 @@ class TestArrayWithDirectoryStore(TestArray):
         # dict as store
         z = self.create_array(shape=1000, chunks=100)
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
         z[:] = 42
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
-        eq(expect_nbytes_stored, z.nbytes_stored)
+        assert expect_nbytes_stored == z.nbytes_stored
 
 
 class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
@@ -1250,38 +1247,18 @@ class TestArrayWithDBMStore(TestArray):
 
 try:
     import bsddb3
-
-    class TestArrayWithDBMStoreBerkeleyDB(TestArray):
-
-        @staticmethod
-        def create_array(read_only=False, **kwargs):
-            path = mktemp(suffix='.dbm')
-            atexit.register(os.remove, path)
-            store = DBMStore(path, flag='n', open=bsddb3.btopen)
-            cache_metadata = kwargs.pop('cache_metadata', True)
-            cache_attrs = kwargs.pop('cache_attrs', True)
-            kwargs.setdefault('compressor', Zlib(1))
-            init_array(store, **kwargs)
-            return Array(store, read_only=read_only, cache_metadata=cache_metadata,
-                         cache_attrs=cache_attrs)
-
-        def test_nbytes_stored(self):
-            pass  # not implemented
-
 except ImportError:  # pragma: no cover
-    pass
+    bsddb3 = None
 
 
-class TestArrayWithLMDBStore(TestArray):
+@pytest.mark.skipif(bsddb3 is None, reason='bsddb3 not installed')
+class TestArrayWithDBMStoreBerkeleyDB(TestArray):
 
     @staticmethod
     def create_array(read_only=False, **kwargs):
-        path = mktemp(suffix='.lmdb')
-        atexit.register(atexit_rmtree, path)
-        try:
-            store = LMDBStore(path, buffers=True)
-        except ImportError:  # pragma: no cover
-            raise SkipTest('lmdb not installed')
+        path = mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStore(path, flag='n', open=bsddb3.btopen)
         cache_metadata = kwargs.pop('cache_metadata', True)
         cache_attrs = kwargs.pop('cache_attrs', True)
         kwargs.setdefault('compressor', Zlib(1))
@@ -1293,16 +1270,39 @@ class TestArrayWithLMDBStore(TestArray):
         pass  # not implemented
 
 
+try:
+    import lmdb
+except ImportError:
+    lmdb = None
+
+
+@pytest.mark.skipif(lmdb is None, reason='lmdb is not installed')
+class TestArrayWithLMDBStore(TestArray):
+
+    @staticmethod
+    def create_array(read_only=False, **kwargs):
+        path = mktemp(suffix='.lmdb')
+        atexit.register(atexit_rmtree, path)
+        store = LMDBStore(path, buffers=True)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, **kwargs)
+        return Array(store, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs)
+
+    def test_nbytes_stored(self):
+        pass  # not implemented
+
+
+@pytest.mark.skipif(lmdb is None, reason='lmdb is not installed')
 class TestArrayWithLMDBStoreNoBuffers(TestArray):
 
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mktemp(suffix='.lmdb')
         atexit.register(atexit_rmtree, path)
-        try:
-            store = LMDBStore(path, buffers=False)
-        except ImportError:  # pragma: no cover
-            raise SkipTest('lmdb not installed')
+        store = LMDBStore(path, buffers=False)
         cache_metadata = kwargs.pop('cache_metadata', True)
         cache_attrs = kwargs.pop('cache_attrs', True)
         kwargs.setdefault('compressor', Zlib(1))
@@ -1328,25 +1328,25 @@ class TestArrayWithNoCompressor(TestArray):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('d3da3d485de4a5fcc6d91f9dfc6a7cba9720c561', z.hexdigest())
+        assert 'd3da3d485de4a5fcc6d91f9dfc6a7cba9720c561' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('443b8dee512e42946cb63ff01d28e9bee8105a5f', z.hexdigest())
+        assert '443b8dee512e42946cb63ff01d28e9bee8105a5f' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('de841ca276042993da53985de1e7769f5d0fc54d', z.hexdigest())
+        assert 'de841ca276042993da53985de1e7769f5d0fc54d' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('42b6ae0d50ec361628736ab7e68fe5fefca22136', z.hexdigest())
+        assert '42b6ae0d50ec361628736ab7e68fe5fefca22136' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('a0535f31c130f5e5ac66ba0713d1c1ceaebd089b', z.hexdigest())
+        assert 'a0535f31c130f5e5ac66ba0713d1c1ceaebd089b' == z.hexdigest()
 
 
 class TestArrayWithBZ2Compressor(TestArray):
@@ -1364,25 +1364,25 @@ class TestArrayWithBZ2Compressor(TestArray):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('33141032439fb1df5e24ad9891a7d845b6c668c8', z.hexdigest())
+        assert '33141032439fb1df5e24ad9891a7d845b6c668c8' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('44d719da065c88a412d609a5500ff41e07b331d6', z.hexdigest())
+        assert '44d719da065c88a412d609a5500ff41e07b331d6' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('f57a9a73a4004490fe1b871688651b8a298a5db7', z.hexdigest())
+        assert 'f57a9a73a4004490fe1b871688651b8a298a5db7' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('1e1bcaac63e4ef3c4a68f11672537131c627f168', z.hexdigest())
+        assert '1e1bcaac63e4ef3c4a68f11672537131c627f168' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('86d7b9bf22dccbeaa22f340f38be506b55e76ff2', z.hexdigest())
+        assert '86d7b9bf22dccbeaa22f340f38be506b55e76ff2' == z.hexdigest()
 
 
 class TestArrayWithBloscCompressor(TestArray):
@@ -1400,28 +1400,28 @@ class TestArrayWithBloscCompressor(TestArray):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('7ff2ae8511eac915fad311647c168ccfe943e788', z.hexdigest())
+        assert '7ff2ae8511eac915fad311647c168ccfe943e788' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('962705c861863495e9ccb7be7735907aa15e85b5', z.hexdigest())
+        assert '962705c861863495e9ccb7be7735907aa15e85b5' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('deb675ff91dd26dba11b65aab5f19a1f21a5645b', z.hexdigest())
+        assert 'deb675ff91dd26dba11b65aab5f19a1f21a5645b' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('90e30bdab745a9641cd0eb605356f531bc8ec1c3', z.hexdigest())
+        assert '90e30bdab745a9641cd0eb605356f531bc8ec1c3' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('95d40c391f167db8b1290e3c39d9bf741edacdf6', z.hexdigest())
+        assert '95d40c391f167db8b1290e3c39d9bf741edacdf6' == z.hexdigest()
 
 
-# TODO can we rely on backports and remove the PY2 exclusion?
+# TODO rely on backports and remove the PY2 exclusion
 if not PY2:  # pragma: py2 no cover
 
     from zarr.codecs import LZMA
@@ -1441,25 +1441,25 @@ if not PY2:  # pragma: py2 no cover
         def test_hexdigest(self):
             # Check basic 1-D array
             z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-            eq('93ecaa530a1162a9d48a3c1dcee4586ccfc59bae', z.hexdigest())
+            assert '93ecaa530a1162a9d48a3c1dcee4586ccfc59bae' == z.hexdigest()
 
             # Check basic 1-D array with different type
             z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-            eq('04a9755a0cd638683531b7816c7fa4fbb6f577f2', z.hexdigest())
+            assert '04a9755a0cd638683531b7816c7fa4fbb6f577f2' == z.hexdigest()
 
             # Check basic 2-D array
             z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-            eq('b93b163a21e8500519250a6defb821d03eb5d9e0', z.hexdigest())
+            assert 'b93b163a21e8500519250a6defb821d03eb5d9e0' == z.hexdigest()
 
             # Check basic 1-D array with some data
             z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
             z[200:400] = np.arange(200, 400, dtype='i4')
-            eq('cde499f3dc945b4e97197ff8e3cf8188a1262c35', z.hexdigest())
+            assert 'cde499f3dc945b4e97197ff8e3cf8188a1262c35' == z.hexdigest()
 
             # Check basic 1-D array with attributes
             z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
             z.attrs['foo'] = 'bar'
-            eq('e2cf3afbf66ad0e28a2b6b68b1b07817c69aaee2', z.hexdigest())
+            assert 'e2cf3afbf66ad0e28a2b6b68b1b07817c69aaee2' == z.hexdigest()
 
 
 class TestArrayWithFilters(TestArray):
@@ -1484,25 +1484,25 @@ class TestArrayWithFilters(TestArray):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('b80367c5599d47110d42bd8886240c2f46620dba', z.hexdigest())
+        assert 'b80367c5599d47110d42bd8886240c2f46620dba' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('95a7b2471225e73199c9716d21e8d3dd6e5f6f2a', z.hexdigest())
+        assert '95a7b2471225e73199c9716d21e8d3dd6e5f6f2a' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('9abf3ad54413ab11855d88a5e0087cd416657e02', z.hexdigest())
+        assert '9abf3ad54413ab11855d88a5e0087cd416657e02' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('c649ad229bc5720258b934ea958570c2f354c2eb', z.hexdigest())
+        assert 'c649ad229bc5720258b934ea958570c2f354c2eb' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('62fc9236d78af18a5ec26c12eea1d33bce52501e', z.hexdigest())
+        assert '62fc9236d78af18a5ec26c12eea1d33bce52501e' == z.hexdigest()
 
     def test_astype_no_filters(self):
         shape = (100,)
@@ -1520,7 +1520,7 @@ class TestArrayWithFilters(TestArray):
 
         expected = data.astype(astype)
         assert_array_equal(expected, z2)
-        eq(z2.read_only, True)
+        assert z2.read_only
 
     def test_astype(self):
         shape = (100,)
@@ -1609,9 +1609,9 @@ class TestArrayWithCustomMapping(TestArray):
 
     def test_nbytes_stored(self):
         z = self.create_array(shape=1000, chunks=100)
-        eq(-1, z.nbytes_stored)
+        assert -1 == z.nbytes_stored
         z[:] = 42
-        eq(-1, z.nbytes_stored)
+        assert -1 == z.nbytes_stored
 
 
 class TestArrayNoCache(TestArray):
@@ -1629,52 +1629,52 @@ class TestArrayNoCache(TestArray):
     def test_cache_metadata(self):
         a1 = self.create_array(shape=100, chunks=10, dtype='i1', cache_metadata=False)
         a2 = Array(a1.store, cache_metadata=True)
-        eq(a1.shape, a2.shape)
-        eq(a1.size, a2.size)
-        eq(a1.nbytes, a2.nbytes)
-        eq(a1.nchunks, a2.nchunks)
+        assert a1.shape == a2.shape
+        assert a1.size == a2.size
+        assert a1.nbytes == a2.nbytes
+        assert a1.nchunks == a2.nchunks
 
         # a1 is not caching so *will* see updates made via other objects
         a2.resize(200)
-        eq((200,), a2.shape)
-        eq(200, a2.size)
-        eq(200, a2.nbytes)
-        eq(20, a2.nchunks)
-        eq(a1.shape, a2.shape)
-        eq(a1.size, a2.size)
-        eq(a1.nbytes, a2.nbytes)
-        eq(a1.nchunks, a2.nchunks)
+        assert (200,) == a2.shape
+        assert 200 == a2.size
+        assert 200 == a2.nbytes
+        assert 20 == a2.nchunks
+        assert a1.shape == a2.shape
+        assert a1.size == a2.size
+        assert a1.nbytes == a2.nbytes
+        assert a1.nchunks == a2.nchunks
 
         a2.append(np.zeros(100))
-        eq((300,), a2.shape)
-        eq(300, a2.size)
-        eq(300, a2.nbytes)
-        eq(30, a2.nchunks)
-        eq(a1.shape, a2.shape)
-        eq(a1.size, a2.size)
-        eq(a1.nbytes, a2.nbytes)
-        eq(a1.nchunks, a2.nchunks)
+        assert (300,) == a2.shape
+        assert 300 == a2.size
+        assert 300 == a2.nbytes
+        assert 30 == a2.nchunks
+        assert a1.shape == a2.shape
+        assert a1.size == a2.size
+        assert a1.nbytes == a2.nbytes
+        assert a1.nchunks == a2.nchunks
 
         # a2 is caching so *will not* see updates made via other objects
         a1.resize(400)
-        eq((400,), a1.shape)
-        eq(400, a1.size)
-        eq(400, a1.nbytes)
-        eq(40, a1.nchunks)
-        eq((300,), a2.shape)
-        eq(300, a2.size)
-        eq(300, a2.nbytes)
-        eq(30, a2.nchunks)
+        assert (400,) == a1.shape
+        assert 400 == a1.size
+        assert 400 == a1.nbytes
+        assert 40 == a1.nchunks
+        assert (300,) == a2.shape
+        assert 300 == a2.size
+        assert 300 == a2.nbytes
+        assert 30 == a2.nchunks
 
     def test_cache_attrs(self):
         a1 = self.create_array(shape=100, chunks=10, dtype='i1', cache_attrs=False)
         a2 = Array(a1.store, cache_attrs=True)
-        eq(a1.attrs.asdict(), a2.attrs.asdict())
+        assert a1.attrs.asdict() == a2.attrs.asdict()
 
         # a1 is not caching so *will* see updates made via other objects
         a2.attrs['foo'] = 'xxx'
         a2.attrs['bar'] = 42
-        eq(a1.attrs.asdict(), a2.attrs.asdict())
+        assert a1.attrs.asdict() == a2.attrs.asdict()
 
         # a2 is caching so *will not* see updates made via other objects
         a1.attrs['foo'] = 'yyy'

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -7,7 +7,6 @@ import warnings
 
 
 import numpy as np
-from nose.tools import eq_ as eq, assert_is_none, assert_is_instance, assert_raises
 from numpy.testing import assert_array_equal
 import pytest
 
@@ -62,22 +61,22 @@ def test_array():
     # with numpy array
     a = np.arange(100)
     z = array(a, chunks=10)
-    eq(a.shape, z.shape)
-    eq(a.dtype, z.dtype)
+    assert a.shape == z.shape
+    assert a.dtype == z.dtype
     assert_array_equal(a, z[:])
 
     # with array-like
     a = list(range(100))
     z = array(a, chunks=10)
-    eq((100,), z.shape)
-    eq(np.asarray(a).dtype, z.dtype)
+    assert (100,) == z.shape
+    assert np.asarray(a).dtype == z.dtype
     assert_array_equal(np.asarray(a), z[:])
 
     # with another zarr array
     z2 = array(z)
-    eq(z.shape, z2.shape)
-    eq(z.chunks, z2.chunks)
-    eq(z.dtype, z2.dtype)
+    assert z.shape == z2.shape
+    assert z.chunks == z2.chunks
+    assert z.dtype == z2.dtype
     assert_array_equal(z[:], z2[:])
 
     # with chunky array-likes
@@ -85,57 +84,57 @@ def test_array():
     b = np.arange(1000).reshape(100, 10)
     c = MockBcolzArray(b, 10)
     z3 = array(c)
-    eq(c.shape, z3.shape)
-    eq((10, 10), z3.chunks)
+    assert c.shape == z3.shape
+    assert (10, 10) == z3.chunks
 
     b = np.arange(1000).reshape(100, 10)
     c = MockH5pyDataset(b, chunks=(10, 2))
     z4 = array(c)
-    eq(c.shape, z4.shape)
-    eq((10, 2), z4.chunks)
+    assert c.shape == z4.shape
+    assert (10, 2) == z4.chunks
 
     c = MockH5pyDataset(b, chunks=None)
     z5 = array(c)
-    eq(c.shape, z5.shape)
-    assert_is_instance(z5.chunks, tuple)
+    assert c.shape == z5.shape
+    assert isinstance(z5.chunks, tuple)
 
     # with dtype=None
     a = np.arange(100, dtype='i4')
     z = array(a, dtype=None)
     assert_array_equal(a[:], z[:])
-    eq(a.dtype, z.dtype)
+    assert a.dtype == z.dtype
 
     # with dtype=something else
     a = np.arange(100, dtype='i4')
     z = array(a, dtype='i8')
     assert_array_equal(a[:], z[:])
-    eq(np.dtype('i8'), z.dtype)
+    assert np.dtype('i8') == z.dtype
 
 
 def test_empty():
     z = empty(100, chunks=10)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
 
 
 def test_zeros():
     z = zeros(100, chunks=10)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert_array_equal(np.zeros(100), z[:])
 
 
 def test_ones():
     z = ones(100, chunks=10)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert_array_equal(np.ones(100), z[:])
 
 
 def test_full():
     z = full(100, chunks=10, fill_value=42, dtype='i4')
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42, dtype='i4'), z[:])
 
     # nan
@@ -145,19 +144,19 @@ def test_full():
     # byte string dtype
     v = b'xxx'
     z = full(100, chunks=10, fill_value=v, dtype='S3')
-    eq(v, z[0])
+    assert v == z[0]
     a = z[...]
-    eq(z.dtype, a.dtype)
-    eq(v, a[0])
+    assert z.dtype == a.dtype
+    assert v == a[0]
     assert np.all(a == v)
 
     # unicode string dtype
     v = u'xxx'
     z = full(100, chunks=10, fill_value=v, dtype='U3')
-    eq(v, z[0])
+    assert v == z[0]
     a = z[...]
-    eq(z.dtype, a.dtype)
-    eq(v, a[0])
+    assert z.dtype == a.dtype
+    assert v == a[0]
     assert np.all(a == v)
 
     # bytes fill value / unicode dtype
@@ -166,12 +165,12 @@ def test_full():
         # allow this on PY2
         z = full(100, chunks=10, fill_value=v, dtype='U3')
         a = z[...]
-        eq(z.dtype, a.dtype)
-        eq(v, a[0])
+        assert z.dtype == a.dtype
+        assert v == a[0]
         assert np.all(a == v)
     else:  # pragma: py2 no cover
         # be strict on PY3
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             full(100, chunks=10, fill_value=v, dtype='U3')
 
 
@@ -182,32 +181,32 @@ def test_open_array():
     # mode == 'w'
     z = open_array(store, mode='w', shape=100, chunks=10)
     z[:] = 42
-    assert_is_instance(z, Array)
-    assert_is_instance(z.store, DirectoryStore)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert isinstance(z, Array)
+    assert isinstance(z.store, DirectoryStore)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
 
     # mode in 'r', 'r+'
     open_group('data/group.zarr', mode='w')
     for mode in 'r', 'r+':
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             open_array('doesnotexist', mode=mode)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             open_array('data/group.zarr', mode=mode)
     z = open_array(store, mode='r')
-    assert_is_instance(z, Array)
-    assert_is_instance(z.store, DirectoryStore)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert isinstance(z, Array)
+    assert isinstance(z.store, DirectoryStore)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
-    with assert_raises(PermissionError):
+    with pytest.raises(PermissionError):
         z[:] = 43
     z = open_array(store, mode='r+')
-    assert_is_instance(z, Array)
-    assert_is_instance(z.store, DirectoryStore)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert isinstance(z, Array)
+    assert isinstance(z.store, DirectoryStore)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
     z[:] = 43
     assert_array_equal(np.full(100, fill_value=43), z[:])
@@ -216,12 +215,12 @@ def test_open_array():
     shutil.rmtree(store)
     z = open_array(store, mode='a', shape=100, chunks=10)
     z[:] = 42
-    assert_is_instance(z, Array)
-    assert_is_instance(z.store, DirectoryStore)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert isinstance(z, Array)
+    assert isinstance(z.store, DirectoryStore)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         open_array('data/group.zarr', mode='a')
 
     # mode in 'w-', 'x'
@@ -229,24 +228,24 @@ def test_open_array():
         shutil.rmtree(store)
         z = open_array(store, mode=mode, shape=100, chunks=10)
         z[:] = 42
-        assert_is_instance(z, Array)
-        assert_is_instance(z.store, DirectoryStore)
-        eq((100,), z.shape)
-        eq((10,), z.chunks)
+        assert isinstance(z, Array)
+        assert isinstance(z.store, DirectoryStore)
+        assert (100,) == z.shape
+        assert (10,) == z.chunks
         assert_array_equal(np.full(100, fill_value=42), z[:])
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             open_array(store, mode=mode)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             open_array('data/group.zarr', mode=mode)
 
     # with synchronizer
     z = open_array(store, synchronizer=ThreadSynchronizer())
-    assert_is_instance(z, Array)
+    assert isinstance(z, Array)
 
     # with path
     z = open_array(store, shape=100, path='foo/bar', mode='w')
-    assert_is_instance(z, Array)
-    eq('foo/bar', z.path)
+    assert isinstance(z, Array)
+    assert 'foo/bar' == z.path
 
 
 def test_empty_like():
@@ -255,40 +254,40 @@ def test_empty_like():
     z = empty(100, chunks=10, dtype='f4', compressor=Zlib(5),
               order='F')
     z2 = empty_like(z)
-    eq(z.shape, z2.shape)
-    eq(z.chunks, z2.chunks)
-    eq(z.dtype, z2.dtype)
-    eq(z.compressor.get_config(), z2.compressor.get_config())
-    eq(z.fill_value, z2.fill_value)
-    eq(z.order, z2.order)
+    assert z.shape == z2.shape
+    assert z.chunks == z2.chunks
+    assert z.dtype == z2.dtype
+    assert z.compressor.get_config() == z2.compressor.get_config()
+    assert z.fill_value == z2.fill_value
+    assert z.order == z2.order
 
     # numpy array
     a = np.empty(100, dtype='f4')
     z3 = empty_like(a)
-    eq(a.shape, z3.shape)
-    eq((100,), z3.chunks)
-    eq(a.dtype, z3.dtype)
-    assert_is_none(z3.fill_value)
+    assert a.shape == z3.shape
+    assert (100,) == z3.chunks
+    assert a.dtype == z3.dtype
+    assert z3.fill_value is None
 
     # something slightly silly
     a = [0] * 100
     z3 = empty_like(a, shape=200)
-    eq((200,), z3.shape)
+    assert (200,) == z3.shape
 
     # other array-likes
     b = np.arange(1000).reshape(100, 10)
     c = MockBcolzArray(b, 10)
     z = empty_like(c)
-    eq(b.shape, z.shape)
-    eq((10, 10), z.chunks)
+    assert b.shape == z.shape
+    assert (10, 10) == z.chunks
     c = MockH5pyDataset(b, chunks=(10, 2))
     z = empty_like(c)
-    eq(b.shape, z.shape)
-    eq((10, 2), z.chunks)
+    assert b.shape == z.shape
+    assert (10, 2) == z.chunks
     c = MockH5pyDataset(b, chunks=None)
     z = empty_like(c)
-    eq(b.shape, z.shape)
-    assert_is_instance(z.chunks, tuple)
+    assert b.shape == z.shape
+    assert isinstance(z.chunks, tuple)
 
 
 def test_zeros_like():
@@ -296,19 +295,19 @@ def test_zeros_like():
     z = zeros(100, chunks=10, dtype='f4', compressor=Zlib(5),
               order='F')
     z2 = zeros_like(z)
-    eq(z.shape, z2.shape)
-    eq(z.chunks, z2.chunks)
-    eq(z.dtype, z2.dtype)
-    eq(z.compressor.get_config(), z2.compressor.get_config())
-    eq(z.fill_value, z2.fill_value)
-    eq(z.order, z2.order)
+    assert z.shape == z2.shape
+    assert z.chunks == z2.chunks
+    assert z.dtype == z2.dtype
+    assert z.compressor.get_config() == z2.compressor.get_config()
+    assert z.fill_value == z2.fill_value
+    assert z.order == z2.order
     # numpy array
     a = np.empty(100, dtype='f4')
     z3 = zeros_like(a, chunks=10)
-    eq(a.shape, z3.shape)
-    eq((10,), z3.chunks)
-    eq(a.dtype, z3.dtype)
-    eq(0, z3.fill_value)
+    assert a.shape == z3.shape
+    assert (10,) == z3.chunks
+    assert a.dtype == z3.dtype
+    assert 0 == z3.fill_value
 
 
 def test_ones_like():
@@ -316,39 +315,39 @@ def test_ones_like():
     z = ones(100, chunks=10, dtype='f4', compressor=Zlib(5),
              order='F')
     z2 = ones_like(z)
-    eq(z.shape, z2.shape)
-    eq(z.chunks, z2.chunks)
-    eq(z.dtype, z2.dtype)
-    eq(z.compressor.get_config(), z2.compressor.get_config())
-    eq(z.fill_value, z2.fill_value)
-    eq(z.order, z2.order)
+    assert z.shape == z2.shape
+    assert z.chunks == z2.chunks
+    assert z.dtype == z2.dtype
+    assert z.compressor.get_config() == z2.compressor.get_config()
+    assert z.fill_value == z2.fill_value
+    assert z.order == z2.order
     # numpy array
     a = np.empty(100, dtype='f4')
     z3 = ones_like(a, chunks=10)
-    eq(a.shape, z3.shape)
-    eq((10,), z3.chunks)
-    eq(a.dtype, z3.dtype)
-    eq(1, z3.fill_value)
+    assert a.shape == z3.shape
+    assert (10,) == z3.chunks
+    assert a.dtype == z3.dtype
+    assert 1 == z3.fill_value
 
 
 def test_full_like():
     z = full(100, chunks=10, dtype='f4', compressor=Zlib(5),
              fill_value=42, order='F')
     z2 = full_like(z)
-    eq(z.shape, z2.shape)
-    eq(z.chunks, z2.chunks)
-    eq(z.dtype, z2.dtype)
-    eq(z.compressor.get_config(), z2.compressor.get_config())
-    eq(z.fill_value, z2.fill_value)
-    eq(z.order, z2.order)
+    assert z.shape == z2.shape
+    assert z.chunks == z2.chunks
+    assert z.dtype == z2.dtype
+    assert z.compressor.get_config() == z2.compressor.get_config()
+    assert z.fill_value == z2.fill_value
+    assert z.order == z2.order
     # numpy array
     a = np.empty(100, dtype='f4')
     z3 = full_like(a, chunks=10, fill_value=42)
-    eq(a.shape, z3.shape)
-    eq((10,), z3.chunks)
-    eq(a.dtype, z3.dtype)
-    eq(42, z3.fill_value)
-    with assert_raises(TypeError):
+    assert a.shape == z3.shape
+    assert (10,) == z3.chunks
+    assert a.dtype == z3.dtype
+    assert 42 == z3.fill_value
+    with pytest.raises(TypeError):
         # fill_value missing
         full_like(a, chunks=10)
 
@@ -360,72 +359,72 @@ def test_open_like():
     z = full(100, chunks=10, dtype='f4', compressor=Zlib(5),
              fill_value=42, order='F')
     z2 = open_like(z, path)
-    eq(z.shape, z2.shape)
-    eq(z.chunks, z2.chunks)
-    eq(z.dtype, z2.dtype)
-    eq(z.compressor.get_config(), z2.compressor.get_config())
-    eq(z.fill_value, z2.fill_value)
-    eq(z.order, z2.order)
+    assert z.shape == z2.shape
+    assert z.chunks == z2.chunks
+    assert z.dtype == z2.dtype
+    assert z.compressor.get_config() == z2.compressor.get_config()
+    assert z.fill_value == z2.fill_value
+    assert z.order == z2.order
     # numpy array
     path = tempfile.mktemp()
     atexit.register(shutil.rmtree, path)
     a = np.empty(100, dtype='f4')
     z3 = open_like(a, path, chunks=10)
-    eq(a.shape, z3.shape)
-    eq((10,), z3.chunks)
-    eq(a.dtype, z3.dtype)
-    eq(0, z3.fill_value)
+    assert a.shape == z3.shape
+    assert (10,) == z3.chunks
+    assert a.dtype == z3.dtype
+    assert 0 == z3.fill_value
 
 
 def test_create():
 
     # defaults
     z = create(100)
-    assert_is_instance(z, Array)
-    eq((100,), z.shape)
-    eq((100,), z.chunks)  # auto-chunks
-    eq(np.dtype(None), z.dtype)
-    eq('blosc', z.compressor.codec_id)
-    eq(0, z.fill_value)
+    assert isinstance(z, Array)
+    assert (100,) == z.shape
+    assert (100,) == z.chunks  # auto-chunks
+    assert np.dtype(None) == z.dtype
+    assert 'blosc' == z.compressor.codec_id
+    assert 0 == z.fill_value
 
     # all specified
     z = create(100, chunks=10, dtype='i4', compressor=Zlib(1),
                fill_value=42, order='F')
-    assert_is_instance(z, Array)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
-    eq(np.dtype('i4'), z.dtype)
-    eq('zlib', z.compressor.codec_id)
-    eq(1, z.compressor.level)
-    eq(42, z.fill_value)
-    eq('F', z.order)
+    assert isinstance(z, Array)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
+    assert np.dtype('i4') == z.dtype
+    assert 'zlib' == z.compressor.codec_id
+    assert 1 == z.compressor.level
+    assert 42 == z.fill_value
+    assert 'F' == z.order
 
     # with synchronizer
     synchronizer = ThreadSynchronizer()
     z = create(100, chunks=10, synchronizer=synchronizer)
-    assert_is_instance(z, Array)
-    eq((100,), z.shape)
-    eq((10,), z.chunks)
+    assert isinstance(z, Array)
+    assert (100,) == z.shape
+    assert (10,) == z.chunks
     assert synchronizer is z.synchronizer
 
     # don't allow string as compressor arg
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         create(100, chunks=10, compressor='zlib')
 
     # h5py compatibility
 
     z = create(100, compression='zlib', compression_opts=9)
-    eq('zlib', z.compressor.codec_id)
-    eq(9, z.compressor.level)
+    assert 'zlib' == z.compressor.codec_id
+    assert 9 == z.compressor.level
 
     z = create(100, compression='default')
-    eq('blosc', z.compressor.codec_id)
+    assert 'blosc' == z.compressor.codec_id
 
     # errors
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         # bad compression argument
         create(100, compression=1)
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         # bad fill value
         create(100, dtype='i4', fill_value='foo')
 
@@ -442,21 +441,21 @@ def test_create():
 def test_compression_args():
 
     z = create(100, compression='zlib', compression_opts=9)
-    assert_is_instance(z, Array)
-    eq('zlib', z.compressor.codec_id)
-    eq(9, z.compressor.level)
+    assert isinstance(z, Array)
+    assert 'zlib' == z.compressor.codec_id
+    assert 9 == z.compressor.level
 
     # 'compressor' overrides 'compression'
     z = create(100, compressor=Zlib(9), compression='bz2', compression_opts=1)
-    assert_is_instance(z, Array)
-    eq('zlib', z.compressor.codec_id)
-    eq(9, z.compressor.level)
+    assert isinstance(z, Array)
+    assert 'zlib' == z.compressor.codec_id
+    assert 9 == z.compressor.level
 
     # 'compressor' ignores 'compression_opts'
     z = create(100, compressor=Zlib(9), compression_opts=1)
-    assert_is_instance(z, Array)
-    eq('zlib', z.compressor.codec_id)
-    eq(9, z.compressor.level)
+    assert isinstance(z, Array)
+    assert 'zlib' == z.compressor.codec_id
+    assert 9 == z.compressor.level
 
     with pytest.warns(UserWarning):
         # 'compressor' overrides 'compression'
@@ -472,13 +471,13 @@ def test_create_read_only():
     # create an array initially read-only, then enable writing
     z = create(100, read_only=True)
     assert z.read_only
-    with assert_raises(PermissionError):
+    with pytest.raises(PermissionError):
         z[:] = 42
     z.read_only = False
     z[:] = 42
     assert np.all(z[...] == 42)
     z.read_only = True
-    with assert_raises(PermissionError):
+    with pytest.raises(PermissionError):
         z[:] = 0
 
     # this is subtly different, but here we want to create an array with data, and then
@@ -487,5 +486,5 @@ def test_create_read_only():
     z = array(a, read_only=True)
     assert_array_equal(a, z[...])
     assert z.read_only
-    with assert_raises(PermissionError):
+    with pytest.raises(PermissionError):
         z[:] = 42

--- a/zarr/tests/test_filters.py
+++ b/zarr/tests/test_filters.py
@@ -4,11 +4,10 @@ from __future__ import absolute_import, print_function, division
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import eq_ as eq
 
 
-from numcodecs import (AsType, Delta, FixedScaleOffset, PackBits, Categorize, Zlib, Blosc, BZ2,
-                       Quantize)
+from numcodecs import (AsType, Delta, FixedScaleOffset, PackBits, Categorize, Zlib, Blosc,
+                       BZ2, Quantize)
 from zarr.creation import array
 from zarr.compat import PY2
 
@@ -20,7 +19,7 @@ compressors = [
     Blosc(),
 ]
 
-# TODO can we rely on backports and remove PY2 exclusion?
+# TODO rely on backports and remove PY2 exclusion
 if not PY2:  # pragma: py2 no cover
     from zarr.codecs import LZMA
     compressors.append(LZMA())
@@ -215,7 +214,7 @@ def test_compressor_as_filter():
         for i in range(10):
             x = bytes(a1.store[str(i)])
             y = bytes(a2.store[str(i)])
-            eq(x, y)
+            assert x == y
 
         # check data
         assert_array_equal(data, a1[:])

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -12,9 +12,6 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from nose.tools import (assert_raises, eq_ as eq, assert_is, assert_true,
-                        assert_is_instance, assert_false, assert_is_none)
-from nose import SkipTest
 import pytest
 
 
@@ -59,76 +56,76 @@ class TestGroup(unittest.TestCase):
     def test_group_init_1(self):
         store, chunk_store = self.create_store()
         g = self.create_group(store, chunk_store=chunk_store)
-        assert_is(store, g.store)
+        assert store is g.store
         if chunk_store is None:
-            assert_is(store, g.chunk_store)
+            assert store is g.chunk_store
         else:
-            assert_is(chunk_store, g.chunk_store)
-        assert_false(g.read_only)
-        eq('', g.path)
-        eq('/', g.name)
-        eq('', g.basename)
-        assert_is_instance(g.attrs, Attributes)
+            assert chunk_store is g.chunk_store
+        assert not g.read_only
+        assert '' == g.path
+        assert '/' == g.name
+        assert '' == g.basename
+        assert isinstance(g.attrs, Attributes)
         g.attrs['foo'] = 'bar'
         assert g.attrs['foo'] == 'bar'
-        assert_is_instance(g.info, InfoReporter)
-        assert_is_instance(repr(g.info), str)
-        assert_is_instance(g.info._repr_html_(), str)
+        assert isinstance(g.info, InfoReporter)
+        assert isinstance(repr(g.info), str)
+        assert isinstance(g.info._repr_html_(), str)
 
     def test_group_init_2(self):
         store, chunk_store = self.create_store()
         g = self.create_group(store, chunk_store=chunk_store,
                               path='/foo/bar/', read_only=True)
-        assert_is(store, g.store)
-        assert_true(g.read_only)
-        eq('foo/bar', g.path)
-        eq('/foo/bar', g.name)
-        eq('bar', g.basename)
-        assert_is_instance(g.attrs, Attributes)
+        assert store is g.store
+        assert g.read_only
+        assert 'foo/bar' == g.path
+        assert '/foo/bar' == g.name
+        assert 'bar' == g.basename
+        assert isinstance(g.attrs, Attributes)
 
     def test_group_init_errors_1(self):
         store, chunk_store = self.create_store()
         # group metadata not initialized
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             Group(store, chunk_store=chunk_store)
 
     def test_group_init_errors_2(self):
         store, chunk_store = self.create_store()
         init_array(store, shape=1000, chunks=100, chunk_store=chunk_store)
         # array blocks group
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             Group(store, chunk_store=chunk_store)
 
     def test_create_group(self):
         g1 = self.create_group()
 
         # check root group
-        eq('', g1.path)
-        eq('/', g1.name)
+        assert '' == g1.path
+        assert '/' == g1.name
 
         # create level 1 child group
         g2 = g1.create_group('foo')
-        assert_is_instance(g2, Group)
-        eq('foo', g2.path)
-        eq('/foo', g2.name)
+        assert isinstance(g2, Group)
+        assert 'foo' == g2.path
+        assert '/foo' == g2.name
 
         # create level 2 child group
         g3 = g2.create_group('bar')
-        assert_is_instance(g3, Group)
-        eq('foo/bar', g3.path)
-        eq('/foo/bar', g3.name)
+        assert isinstance(g3, Group)
+        assert 'foo/bar' == g3.path
+        assert '/foo/bar' == g3.name
 
         # create level 3 child group
         g4 = g1.create_group('foo/bar/baz')
-        assert_is_instance(g4, Group)
-        eq('foo/bar/baz', g4.path)
-        eq('/foo/bar/baz', g4.name)
+        assert isinstance(g4, Group)
+        assert 'foo/bar/baz' == g4.path
+        assert '/foo/bar/baz' == g4.name
 
         # create level 3 group via root
         g5 = g4.create_group('/a/b/c/')
-        assert_is_instance(g5, Group)
-        eq('a/b/c', g5.path)
-        eq('/a/b/c', g5.name)
+        assert isinstance(g5, Group)
+        assert 'a/b/c' == g5.path
+        assert '/a/b/c' == g5.name
 
         # test non-str keys
         class Foo(object):
@@ -141,113 +138,113 @@ class TestGroup(unittest.TestCase):
 
         o = Foo('test/object')
         go = g1.create_group(o)
-        assert_is_instance(go, Group)
-        eq('test/object', go.path)
+        assert isinstance(go, Group)
+        assert 'test/object' == go.path
         go = g1.create_group(b'test/bytes')
-        assert_is_instance(go, Group)
-        eq('test/bytes', go.path)
+        assert isinstance(go, Group)
+        assert 'test/bytes' == go.path
 
         # test bad keys
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1.create_group('foo')  # already exists
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1.create_group('a/b/c')  # already exists
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g4.create_group('/a/b/c')  # already exists
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1.create_group('')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1.create_group('/')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1.create_group('//')
 
         # multi
         g6, g7 = g1.create_groups('y', 'z')
-        assert_is_instance(g6, Group)
-        eq(g6.path, 'y')
-        assert_is_instance(g7, Group)
-        eq(g7.path, 'z')
+        assert isinstance(g6, Group)
+        assert g6.path == 'y'
+        assert isinstance(g7, Group)
+        assert g7.path == 'z'
 
     def test_require_group(self):
         g1 = self.create_group()
 
         # test creation
         g2 = g1.require_group('foo')
-        assert_is_instance(g2, Group)
-        eq('foo', g2.path)
+        assert isinstance(g2, Group)
+        assert 'foo' == g2.path
         g3 = g2.require_group('bar')
-        assert_is_instance(g3, Group)
-        eq('foo/bar', g3.path)
+        assert isinstance(g3, Group)
+        assert 'foo/bar' == g3.path
         g4 = g1.require_group('foo/bar/baz')
-        assert_is_instance(g4, Group)
-        eq('foo/bar/baz', g4.path)
+        assert isinstance(g4, Group)
+        assert 'foo/bar/baz' == g4.path
         g5 = g4.require_group('/a/b/c/')
-        assert_is_instance(g5, Group)
-        eq('a/b/c', g5.path)
+        assert isinstance(g5, Group)
+        assert 'a/b/c' == g5.path
 
         # test when already created
         g2a = g1.require_group('foo')
-        eq(g2, g2a)
-        assert_is(g2.store, g2a.store)
+        assert g2 == g2a
+        assert g2.store is g2a.store
         g3a = g2a.require_group('bar')
-        eq(g3, g3a)
-        assert_is(g3.store, g3a.store)
+        assert g3 == g3a
+        assert g3.store is g3a.store
         g4a = g1.require_group('foo/bar/baz')
-        eq(g4, g4a)
-        assert_is(g4.store, g4a.store)
+        assert g4 == g4a
+        assert g4.store is g4a.store
         g5a = g4a.require_group('/a/b/c/')
-        eq(g5, g5a)
-        assert_is(g5.store, g5a.store)
+        assert g5 == g5a
+        assert g5.store is g5a.store
 
         # test path normalization
-        eq(g1.require_group('quux'), g1.require_group('/quux/'))
+        assert g1.require_group('quux') == g1.require_group('/quux/')
 
         # multi
         g6, g7 = g1.require_groups('y', 'z')
-        assert_is_instance(g6, Group)
-        eq(g6.path, 'y')
-        assert_is_instance(g7, Group)
-        eq(g7.path, 'z')
+        assert isinstance(g6, Group)
+        assert g6.path == 'y'
+        assert isinstance(g7, Group)
+        assert g7.path == 'z'
 
     def test_create_dataset(self):
         g = self.create_group()
 
         # create as immediate child
         d1 = g.create_dataset('foo', shape=1000, chunks=100)
-        assert_is_instance(d1, Array)
-        eq((1000,), d1.shape)
-        eq((100,), d1.chunks)
-        eq('foo', d1.path)
-        eq('/foo', d1.name)
-        assert_is(g.store, d1.store)
+        assert isinstance(d1, Array)
+        assert (1000,) == d1.shape
+        assert (100,) == d1.chunks
+        assert 'foo' == d1.path
+        assert '/foo' == d1.name
+        assert g.store is d1.store
 
         # create as descendant
         d2 = g.create_dataset('/a/b/c/', shape=2000, chunks=200, dtype='i1',
                               compression='zlib', compression_opts=9,
                               fill_value=42, order='F')
-        assert_is_instance(d2, Array)
-        eq((2000,), d2.shape)
-        eq((200,), d2.chunks)
-        eq(np.dtype('i1'), d2.dtype)
-        eq('zlib', d2.compressor.codec_id)
-        eq(9, d2.compressor.level)
-        eq(42, d2.fill_value)
-        eq('F', d2.order)
-        eq('a/b/c', d2.path)
-        eq('/a/b/c', d2.name)
-        assert_is(g.store, d2.store)
+        assert isinstance(d2, Array)
+        assert (2000,) == d2.shape
+        assert (200,) == d2.chunks
+        assert np.dtype('i1') == d2.dtype
+        assert 'zlib' == d2.compressor.codec_id
+        assert 9 == d2.compressor.level
+        assert 42 == d2.fill_value
+        assert 'F' == d2.order
+        assert 'a/b/c' == d2.path
+        assert '/a/b/c' == d2.name
+        assert g.store is d2.store
 
         # create with data
         data = np.arange(3000, dtype='u2')
         d3 = g.create_dataset('bar', data=data, chunks=300)
-        assert_is_instance(d3, Array)
-        eq((3000,), d3.shape)
-        eq((300,), d3.chunks)
-        eq(np.dtype('u2'), d3.dtype)
+        assert isinstance(d3, Array)
+        assert (3000,) == d3.shape
+        assert (300,) == d3.chunks
+        assert np.dtype('u2') == d3.dtype
         assert_array_equal(data, d3[:])
-        eq('bar', d3.path)
-        eq('/bar', d3.name)
-        assert_is(g.store, d3.store)
+        assert 'bar' == d3.path
+        assert '/bar' == d3.name
+        assert g.store is d3.store
 
         # compression arguments handling follows...
 
@@ -255,33 +252,33 @@ class TestGroup(unittest.TestCase):
         d = g.create_dataset('aaa', shape=1000, dtype='u1',
                              compression='blosc',
                              compression_opts=dict(cname='zstd', clevel=1, shuffle=2))
-        eq(d.compressor.codec_id, 'blosc')
-        eq('zstd', d.compressor.cname)
-        eq(1, d.compressor.clevel)
-        eq(2, d.compressor.shuffle)
+        assert d.compressor.codec_id == 'blosc'
+        assert 'zstd' == d.compressor.cname
+        assert 1 == d.compressor.clevel
+        assert 2 == d.compressor.shuffle
 
         # compression_opts as sequence
         d = g.create_dataset('bbb', shape=1000, dtype='u1',
                              compression='blosc',
                              compression_opts=('zstd', 1, 2))
-        eq(d.compressor.codec_id, 'blosc')
-        eq('zstd', d.compressor.cname)
-        eq(1, d.compressor.clevel)
-        eq(2, d.compressor.shuffle)
+        assert d.compressor.codec_id == 'blosc'
+        assert 'zstd' == d.compressor.cname
+        assert 1 == d.compressor.clevel
+        assert 2 == d.compressor.shuffle
 
         # None compression_opts
         d = g.create_dataset('ccc', shape=1000, dtype='u1', compression='zlib')
-        eq(d.compressor.codec_id, 'zlib')
-        eq(1, d.compressor.level)
+        assert d.compressor.codec_id == 'zlib'
+        assert 1 == d.compressor.level
 
         # None compression
         d = g.create_dataset('ddd', shape=1000, dtype='u1', compression=None)
-        assert_is_none(d.compressor)
+        assert d.compressor is None
 
         # compressor as compression
         d = g.create_dataset('eee', shape=1000, dtype='u1', compression=Zlib(1))
-        eq(d.compressor.codec_id, 'zlib')
-        eq(1, d.compressor.level)
+        assert d.compressor.codec_id == 'zlib'
+        assert 1 == d.compressor.level
 
     def test_require_dataset(self):
         g = self.create_group()
@@ -289,40 +286,40 @@ class TestGroup(unittest.TestCase):
         # create
         d1 = g.require_dataset('foo', shape=1000, chunks=100, dtype='f4')
         d1[:] = np.arange(1000)
-        assert_is_instance(d1, Array)
-        eq((1000,), d1.shape)
-        eq((100,), d1.chunks)
-        eq(np.dtype('f4'), d1.dtype)
-        eq('foo', d1.path)
-        eq('/foo', d1.name)
-        assert_is(g.store, d1.store)
+        assert isinstance(d1, Array)
+        assert (1000,) == d1.shape
+        assert (100,) == d1.chunks
+        assert np.dtype('f4') == d1.dtype
+        assert 'foo' == d1.path
+        assert '/foo' == d1.name
+        assert g.store is d1.store
         assert_array_equal(np.arange(1000), d1[:])
 
         # require
         d2 = g.require_dataset('foo', shape=1000, chunks=100, dtype='f4')
-        assert_is_instance(d2, Array)
-        eq((1000,), d2.shape)
-        eq((100,), d2.chunks)
-        eq(np.dtype('f4'), d2.dtype)
-        eq('foo', d2.path)
-        eq('/foo', d2.name)
-        assert_is(g.store, d2.store)
+        assert isinstance(d2, Array)
+        assert (1000,) == d2.shape
+        assert (100,) == d2.chunks
+        assert np.dtype('f4') == d2.dtype
+        assert 'foo' == d2.path
+        assert '/foo' == d2.name
+        assert g.store is d2.store
         assert_array_equal(np.arange(1000), d2[:])
-        eq(d1, d2)
+        assert d1 == d2
 
         # bad shape - use TypeError for h5py compatibility
-        with assert_raises(TypeError):
+        with pytest.raises(TypeError):
             g.require_dataset('foo', shape=2000, chunks=100, dtype='f4')
 
         # dtype matching
         # can cast
         d3 = g.require_dataset('foo', shape=1000, chunks=100, dtype='i2')
-        eq(np.dtype('f4'), d3.dtype)
-        eq(d1, d3)
-        with assert_raises(TypeError):
+        assert np.dtype('f4') == d3.dtype
+        assert d1 == d3
+        with pytest.raises(TypeError):
             # cannot cast
             g.require_dataset('foo', shape=1000, chunks=100, dtype='i4')
-        with assert_raises(TypeError):
+        with pytest.raises(TypeError):
             # can cast but not exact match
             g.require_dataset('foo', shape=1000, chunks=100, dtype='i2',
                               exact=True)
@@ -332,38 +329,38 @@ class TestGroup(unittest.TestCase):
 
         # array obstructs group, array
         g.create_dataset('foo', shape=100, chunks=10)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.create_group('foo/bar')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.require_group('foo/bar')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.create_dataset('foo/bar', shape=100, chunks=10)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.require_dataset('foo/bar', shape=100, chunks=10)
 
         # array obstructs group, array
         g.create_dataset('a/b', shape=100, chunks=10)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.create_group('a/b')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.require_group('a/b')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.create_dataset('a/b', shape=100, chunks=10)
 
         # group obstructs array
         g.create_group('c/d')
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.create_dataset('c', shape=100, chunks=10)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.require_dataset('c', shape=100, chunks=10)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.create_dataset('c/d', shape=100, chunks=10)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g.require_dataset('c/d', shape=100, chunks=10)
 
         # h5py compatibility, accept 'fillvalue'
         d = g.create_dataset('x', shape=100, chunks=10, fillvalue=42)
-        eq(42, d.fill_value)
+        assert 42 == d.fill_value
 
         # h5py compatibility, ignore 'shuffle'
         with pytest.warns(UserWarning, match="ignoring keyword argument 'shuffle'"):
@@ -371,13 +368,13 @@ class TestGroup(unittest.TestCase):
 
         # read-only
         g = self.create_group(read_only=True)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             g.create_group('zzz')
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             g.require_group('zzz')
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             g.create_dataset('zzz', shape=100, chunks=10)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             g.require_dataset('zzz', shape=100, chunks=10)
 
     def test_create_overwrite(self):
@@ -390,19 +387,19 @@ class TestGroup(unittest.TestCase):
                 # overwrite array with array
                 d = getattr(g, method_name)('foo', shape=200, chunks=20,
                                             overwrite=True)
-                eq((200,), d.shape)
+                assert (200,) == d.shape
                 # overwrite array with group
                 g2 = g.create_group('foo', overwrite=True)
-                eq(0, len(g2))
+                assert 0 == len(g2)
                 # overwrite group with array
                 d = getattr(g, method_name)('foo', shape=300, chunks=30,
                                             overwrite=True)
-                eq((300,), d.shape)
+                assert (300,) == d.shape
                 # overwrite array with group
                 d = getattr(g, method_name)('foo/bar', shape=400, chunks=40,
                                             overwrite=True)
-                eq((400,), d.shape)
-                assert_is_instance(g['foo'], Group)
+                assert (400,) == d.shape
+                assert isinstance(g['foo'], Group)
         except NotImplementedError:
             pass
 
@@ -416,22 +413,22 @@ class TestGroup(unittest.TestCase):
         d2[:] = np.arange(3000)
 
         # test __getitem__
-        assert_is_instance(g1['foo'], Group)
-        assert_is_instance(g1['foo']['bar'], Group)
-        assert_is_instance(g1['foo/bar'], Group)
-        assert_is_instance(g1['/foo/bar/'], Group)
-        assert_is_instance(g1['foo/baz'], Array)
-        eq(g2, g1['foo/bar'])
-        eq(g1['foo']['bar'], g1['foo/bar'])
-        eq(d2, g1['foo/baz'])
+        assert isinstance(g1['foo'], Group)
+        assert isinstance(g1['foo']['bar'], Group)
+        assert isinstance(g1['foo/bar'], Group)
+        assert isinstance(g1['/foo/bar/'], Group)
+        assert isinstance(g1['foo/baz'], Array)
+        assert g2 == g1['foo/bar']
+        assert g1['foo']['bar'] == g1['foo/bar']
+        assert d2 == g1['foo/baz']
         assert_array_equal(d2[:], g1['foo/baz'])
-        assert_is_instance(g1['a'], Group)
-        assert_is_instance(g1['a']['b'], Group)
-        assert_is_instance(g1['a/b'], Group)
-        assert_is_instance(g1['a']['b']['c'], Array)
-        assert_is_instance(g1['a/b/c'], Array)
-        eq(d1, g1['a/b/c'])
-        eq(g1['a']['b']['c'], g1['a/b/c'])
+        assert isinstance(g1['a'], Group)
+        assert isinstance(g1['a']['b'], Group)
+        assert isinstance(g1['a/b'], Group)
+        assert isinstance(g1['a']['b']['c'], Array)
+        assert isinstance(g1['a/b/c'], Array)
+        assert d1 == g1['a/b/c']
+        assert g1['a']['b']['c'] == g1['a/b/c']
         assert_array_equal(d1[:], g1['a/b/c'][:])
 
         # test __contains__
@@ -448,70 +445,70 @@ class TestGroup(unittest.TestCase):
         assert 'quux' not in g1['foo']
 
         # test key errors
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             g1['baz']
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             g1['x/y/z']
 
         # test __len__
-        eq(2, len(g1))
-        eq(2, len(g1['foo']))
-        eq(0, len(g1['foo/bar']))
-        eq(1, len(g1['a']))
-        eq(1, len(g1['a/b']))
+        assert 2 == len(g1)
+        assert 2 == len(g1['foo'])
+        assert 0 == len(g1['foo/bar'])
+        assert 1 == len(g1['a'])
+        assert 1 == len(g1['a/b'])
 
         # test __iter__, keys()
         # currently assumes sorted by key
 
-        eq(['a', 'foo'], list(g1))
-        eq(['a', 'foo'], list(g1.keys()))
-        eq(['bar', 'baz'], list(g1['foo']))
-        eq(['bar', 'baz'], list(g1['foo'].keys()))
-        eq([], sorted(g1['foo/bar']))
-        eq([], sorted(g1['foo/bar'].keys()))
+        assert ['a', 'foo'] == list(g1)
+        assert ['a', 'foo'] == list(g1.keys())
+        assert ['bar', 'baz'] == list(g1['foo'])
+        assert ['bar', 'baz'] == list(g1['foo'].keys())
+        assert [] == sorted(g1['foo/bar'])
+        assert [] == sorted(g1['foo/bar'].keys())
 
         # test items(), values()
         # currently assumes sorted by key
 
         items = list(g1.items())
         values = list(g1.values())
-        eq('a', items[0][0])
-        eq(g1['a'], items[0][1])
-        eq(g1['a'], values[0])
-        eq('foo', items[1][0])
-        eq(g1['foo'], items[1][1])
-        eq(g1['foo'], values[1])
+        assert 'a' == items[0][0]
+        assert g1['a'] == items[0][1]
+        assert g1['a'] == values[0]
+        assert 'foo' == items[1][0]
+        assert g1['foo'] == items[1][1]
+        assert g1['foo'] == values[1]
 
         items = list(g1['foo'].items())
         values = list(g1['foo'].values())
-        eq('bar', items[0][0])
-        eq(g1['foo']['bar'], items[0][1])
-        eq(g1['foo']['bar'], values[0])
-        eq('baz', items[1][0])
-        eq(g1['foo']['baz'], items[1][1])
-        eq(g1['foo']['baz'], values[1])
+        assert 'bar' == items[0][0]
+        assert g1['foo']['bar'] == items[0][1]
+        assert g1['foo']['bar'] == values[0]
+        assert 'baz' == items[1][0]
+        assert g1['foo']['baz'] == items[1][1]
+        assert g1['foo']['baz'] == values[1]
 
         # test array_keys(), arrays(), group_keys(), groups()
         # currently assumes sorted by key
 
-        eq(['a', 'foo'], list(g1.group_keys()))
+        assert ['a', 'foo'] == list(g1.group_keys())
         groups = list(g1.groups())
         arrays = list(g1.arrays())
-        eq('a', groups[0][0])
-        eq(g1['a'], groups[0][1])
-        eq('foo', groups[1][0])
-        eq(g1['foo'], groups[1][1])
-        eq([], list(g1.array_keys()))
-        eq([], arrays)
+        assert 'a' == groups[0][0]
+        assert g1['a'] == groups[0][1]
+        assert 'foo' == groups[1][0]
+        assert g1['foo'] == groups[1][1]
+        assert [] == list(g1.array_keys())
+        assert [] == arrays
 
-        eq(['bar'], list(g1['foo'].group_keys()))
-        eq(['baz'], list(g1['foo'].array_keys()))
+        assert ['bar'] == list(g1['foo'].group_keys())
+        assert ['baz'] == list(g1['foo'].array_keys())
         groups = list(g1['foo'].groups())
         arrays = list(g1['foo'].arrays())
-        eq('bar', groups[0][0])
-        eq(g1['foo']['bar'], groups[0][1])
-        eq('baz', arrays[0][0])
-        eq(g1['foo']['baz'], arrays[0][1])
+        assert 'bar' == groups[0][0]
+        assert g1['foo']['bar'] == groups[0][1]
+        assert 'baz' == arrays[0][0]
+        assert g1['foo']['baz'] == arrays[0][1]
 
         # visitor collection tests
         items = []
@@ -519,6 +516,7 @@ class TestGroup(unittest.TestCase):
         def visitor2(obj):
             items.append(obj.path)
 
+        # noinspection PyUnusedLocal
         def visitor3(name, obj=None):
             items.append(name)
 
@@ -527,114 +525,116 @@ class TestGroup(unittest.TestCase):
 
         del items[:]
         g1.visitvalues(visitor2)
-        eq([
+        assert [
             "a",
             "a/b",
             "a/b/c",
             "foo",
             "foo/bar",
             "foo/baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1["foo"].visitvalues(visitor2)
-        eq([
+        assert [
             "foo/bar",
             "foo/baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1.visit(visitor3)
-        eq([
+        assert [
             "a",
             "a/b",
             "a/b/c",
             "foo",
             "foo/bar",
             "foo/baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1["foo"].visit(visitor3)
-        eq([
+        assert [
             "bar",
             "baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1.visitkeys(visitor3)
-        eq([
+        assert [
             "a",
             "a/b",
             "a/b/c",
             "foo",
             "foo/bar",
             "foo/baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1["foo"].visitkeys(visitor3)
-        eq([
+        assert [
             "bar",
             "baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1.visititems(visitor3)
-        eq([
+        assert [
             "a",
             "a/b",
             "a/b/c",
             "foo",
             "foo/bar",
             "foo/baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1["foo"].visititems(visitor3)
-        eq([
+        assert [
             "bar",
             "baz",
-        ], items)
+        ] == items
 
         del items[:]
         g1.visititems(visitor4)
         for n, o in items:
-            eq(g1[n], o)
+            assert g1[n] == o
 
         del items[:]
         g1["foo"].visititems(visitor4)
         for n, o in items:
-            eq(g1["foo"][n], o)
+            assert g1["foo"][n] == o
 
         # visitor filter tests
+        # noinspection PyUnusedLocal
         def visitor0(val, *args):
             name = getattr(val, "path", val)
             if name == "a/b/c/d":
                 return True  # pragma: no cover
 
+        # noinspection PyUnusedLocal
         def visitor1(val, *args):
             name = getattr(val, "path", val)
             if name == "a/b/c":
                 return True
 
-        eq(None, g1.visit(visitor0))
-        eq(None, g1.visitkeys(visitor0))
-        eq(None, g1.visitvalues(visitor0))
-        eq(None, g1.visititems(visitor0))
-        eq(True, g1.visit(visitor1))
-        eq(True, g1.visitkeys(visitor1))
-        eq(True, g1.visitvalues(visitor1))
-        eq(True, g1.visititems(visitor1))
+        assert g1.visit(visitor0) is None
+        assert g1.visitkeys(visitor0) is None
+        assert g1.visitvalues(visitor0) is None
+        assert g1.visititems(visitor0) is None
+        assert g1.visit(visitor1) is True
+        assert g1.visitkeys(visitor1) is True
+        assert g1.visitvalues(visitor1) is True
+        assert g1.visititems(visitor1) is True
 
     def test_empty_getitem_contains_iterators(self):
         # setup
         g = self.create_group()
 
         # test
-        eq([], list(g))
-        eq([], list(g.keys()))
-        eq(0, len(g))
+        assert [] == list(g)
+        assert [] == list(g.keys())
+        assert 0 == len(g)
         assert 'foo' not in g
 
     def test_getattr(self):
@@ -644,10 +644,10 @@ class TestGroup(unittest.TestCase):
         g2.create_dataset('bar', shape=100)
 
         # test
-        eq(g1['foo'], g1.foo)
-        eq(g2['bar'], g2.bar)
+        assert g1['foo'] == g1.foo
+        assert g2['bar'] == g2.bar
         # test that hasattr returns False instead of an exception (issue #88)
-        assert_false(hasattr(g1, 'unexistingattribute'))
+        assert not hasattr(g1, 'unexistingattribute')
 
     def test_setitem(self):
         g = self.create_group()
@@ -660,8 +660,8 @@ class TestGroup(unittest.TestCase):
             assert_array_equal(data, g['foo'])
             # 0d array
             g['foo'] = 42
-            eq((), g['foo'].shape)
-            eq(42, g['foo'][()])
+            assert () == g['foo'].shape
+            assert 42 == g['foo'][()]
         except NotImplementedError:
             pass
 
@@ -674,7 +674,7 @@ class TestGroup(unittest.TestCase):
         assert 'bar/baz' in g
         try:
             del g['bar']
-            with assert_raises(KeyError):
+            with pytest.raises(KeyError):
                 del g['xxx']
         except NotImplementedError:
             pass
@@ -721,10 +721,10 @@ class TestGroup(unittest.TestCase):
             assert isinstance(g['foo2'], Group)
             assert_array_equal(data, g['bar'])
 
-            with assert_raises(ValueError):
+            with pytest.raises(ValueError):
                 g2.move('bar', 'bar2')
 
-            with assert_raises(ValueError):
+            with pytest.raises(ValueError):
                 g.move('bar', 'boo')
         except NotImplementedError:
             pass
@@ -733,90 +733,90 @@ class TestGroup(unittest.TestCase):
         grp = self.create_group()
 
         a = grp.create('a', shape=100, chunks=10)
-        assert_is_instance(a, Array)
+        assert isinstance(a, Array)
         b = grp.empty('b', shape=100, chunks=10)
-        assert_is_instance(b, Array)
-        assert_is_none(b.fill_value)
+        assert isinstance(b, Array)
+        assert b.fill_value is None
         c = grp.zeros('c', shape=100, chunks=10)
-        assert_is_instance(c, Array)
-        eq(0, c.fill_value)
+        assert isinstance(c, Array)
+        assert 0 == c.fill_value
         d = grp.ones('d', shape=100, chunks=10)
-        assert_is_instance(d, Array)
-        eq(1, d.fill_value)
+        assert isinstance(d, Array)
+        assert 1 == d.fill_value
         e = grp.full('e', shape=100, chunks=10, fill_value=42)
-        assert_is_instance(e, Array)
-        eq(42, e.fill_value)
+        assert isinstance(e, Array)
+        assert 42 == e.fill_value
 
         f = grp.empty_like('f', a)
-        assert_is_instance(f, Array)
-        assert_is_none(f.fill_value)
+        assert isinstance(f, Array)
+        assert f.fill_value is None
         g = grp.zeros_like('g', a)
-        assert_is_instance(g, Array)
-        eq(0, g.fill_value)
+        assert isinstance(g, Array)
+        assert 0 == g.fill_value
         h = grp.ones_like('h', a)
-        assert_is_instance(h, Array)
-        eq(1, h.fill_value)
+        assert isinstance(h, Array)
+        assert 1 == h.fill_value
         i = grp.full_like('i', e)
-        assert_is_instance(i, Array)
-        eq(42, i.fill_value)
+        assert isinstance(i, Array)
+        assert 42 == i.fill_value
 
         j = grp.array('j', data=np.arange(100), chunks=10)
-        assert_is_instance(j, Array)
+        assert isinstance(j, Array)
         assert_array_equal(np.arange(100), j[:])
 
         grp = self.create_group(read_only=True)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.create('aa', shape=100, chunks=10)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.empty('aa', shape=100, chunks=10)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.zeros('aa', shape=100, chunks=10)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.ones('aa', shape=100, chunks=10)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.full('aa', shape=100, chunks=10, fill_value=42)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.array('aa', data=np.arange(100), chunks=10)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.create('aa', shape=100, chunks=10)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.empty_like('aa', a)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.zeros_like('aa', a)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.ones_like('aa', a)
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             grp.full_like('aa', a)
 
     def test_paths(self):
         g1 = self.create_group()
         g2 = g1.create_group('foo/bar')
 
-        eq(g1, g1['/'])
-        eq(g1, g1['//'])
-        eq(g1, g1['///'])
-        eq(g1, g2['/'])
-        eq(g1, g2['//'])
-        eq(g1, g2['///'])
-        eq(g2, g1['foo/bar'])
-        eq(g2, g1['/foo/bar'])
-        eq(g2, g1['foo/bar/'])
-        eq(g2, g1['//foo/bar'])
-        eq(g2, g1['//foo//bar//'])
-        eq(g2, g1['///foo///bar///'])
-        eq(g2, g2['/foo/bar'])
+        assert g1 == g1['/']
+        assert g1 == g1['//']
+        assert g1 == g1['///']
+        assert g1 == g2['/']
+        assert g1 == g2['//']
+        assert g1 == g2['///']
+        assert g2 == g1['foo/bar']
+        assert g2 == g1['/foo/bar']
+        assert g2 == g1['foo/bar/']
+        assert g2 == g1['//foo/bar']
+        assert g2 == g1['//foo//bar//']
+        assert g2 == g1['///foo///bar///']
+        assert g2 == g2['/foo/bar']
 
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1['.']
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1['..']
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1['foo/.']
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1['foo/..']
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1['foo/./bar']
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             g1['foo/../bar']
 
     def test_pickle(self):
@@ -831,12 +831,12 @@ class TestGroup(unittest.TestCase):
 
         # pickle round trip
         g2 = pickle.loads(pickle.dumps(g))
-        eq(g.path, g2.path)
-        eq(g.name, g2.name)
-        eq(len(g), len(g2))
-        eq(list(g), list(g2))
-        eq(g['foo'], g2['foo'])
-        eq(g['foo/bar'], g2['foo/bar'])
+        assert g.path == g2.path
+        assert g.name == g2.name
+        assert len(g) == len(g2)
+        assert list(g) == list(g2)
+        assert g['foo'] == g2['foo']
+        assert g['foo/bar'] == g2['foo/bar']
 
 
 class TestGroupWithDictStore(TestGroup):
@@ -888,30 +888,35 @@ class TestGroupWithDBMStore(TestGroup):
 
 try:
     import bsddb3
-
-    class TestGroupWithDBMStoreBerkeleyDB(TestGroup):
-
-        @staticmethod
-        def create_store():
-            path = tempfile.mktemp(suffix='.dbm')
-            atexit.register(os.remove, path)
-            store = DBMStore(path, flag='n', open=bsddb3.btopen)
-            return store, None
-
 except ImportError:  # pragma: no cover
-    pass
+    bsddb3 = None
 
 
+@pytest.mark.skipif(bsddb3 is None, reason='bsddb3 is not installed')
+class TestGroupWithDBMStoreBerkeleyDB(TestGroup):
+
+    @staticmethod
+    def create_store():
+        path = tempfile.mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStore(path, flag='n', open=bsddb3.btopen)
+        return store, None
+
+
+try:
+    import lmdb
+except ImportError:
+    lmdb = None
+
+
+@pytest.mark.skipif(lmdb is None, reason='lmdb is not installed')
 class TestGroupWithLMDBStore(TestGroup):
 
     @staticmethod
     def create_store():
         path = tempfile.mktemp(suffix='.lmdb')
         atexit.register(atexit_rmtree, path)
-        try:
-            store = LMDBStore(path)
-        except ImportError:  # pragma: no cover
-            raise SkipTest('lmdb nod installed')
+        store = LMDBStore(path)
         return store, None
 
 
@@ -927,23 +932,23 @@ class TestGroupWithChunkStore(TestGroup):
         g = self.create_group(store, chunk_store=chunk_store)
 
         # check attributes
-        assert_is(store, g.store)
-        assert_is(chunk_store, g.chunk_store)
+        assert store is g.store
+        assert chunk_store is g.chunk_store
 
         # create array
         a = g.zeros('foo', shape=100, chunks=10)
-        assert_is(store, a.store)
-        assert_is(chunk_store, a.chunk_store)
+        assert store is a.store
+        assert chunk_store is a.chunk_store
         a[:] = np.arange(100)
         assert_array_equal(np.arange(100), a[:])
 
         # check store keys
         expect = sorted([group_meta_key, 'foo/' + array_meta_key])
         actual = sorted(store.keys())
-        eq(expect, actual)
+        assert expect == actual
         expect = ['foo/' + str(i) for i in range(10)]
         actual = sorted(chunk_store.keys())
-        eq(expect, actual)
+        assert expect == actual
 
 
 class TestGroupWithStoreCache(TestGroup):
@@ -959,24 +964,24 @@ def test_group():
 
     # basic usage
     g = group()
-    assert_is_instance(g, Group)
-    eq('', g.path)
-    eq('/', g.name)
+    assert isinstance(g, Group)
+    assert '' == g.path
+    assert '/' == g.name
 
     # usage with custom store
     store = dict()
     g = group(store=store)
-    assert_is_instance(g, Group)
-    assert_is(store, g.store)
+    assert isinstance(g, Group)
+    assert store is g.store
 
     # overwrite behaviour
     store = dict()
     init_array(store, shape=100, chunks=10)
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         group(store)
     g = group(store, overwrite=True)
-    assert_is_instance(g, Group)
-    assert_is(store, g.store)
+    assert isinstance(g, Group)
+    assert store is g.store
 
 
 def test_open_group():
@@ -986,59 +991,59 @@ def test_open_group():
 
     # mode == 'w'
     g = open_group(store, mode='w')
-    assert_is_instance(g, Group)
-    assert_is_instance(g.store, DirectoryStore)
-    eq(0, len(g))
+    assert isinstance(g, Group)
+    assert isinstance(g.store, DirectoryStore)
+    assert 0 == len(g)
     g.create_groups('foo', 'bar')
-    eq(2, len(g))
+    assert 2 == len(g)
 
     # mode in 'r', 'r+'
     open_array('data/array.zarr', shape=100, chunks=10, mode='w')
     for mode in 'r', 'r+':
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             open_group('doesnotexist', mode=mode)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             open_group('data/array.zarr', mode=mode)
     g = open_group(store, mode='r')
-    assert_is_instance(g, Group)
-    eq(2, len(g))
-    with assert_raises(PermissionError):
+    assert isinstance(g, Group)
+    assert 2 == len(g)
+    with pytest.raises(PermissionError):
         g.create_group('baz')
     g = open_group(store, mode='r+')
-    assert_is_instance(g, Group)
-    eq(2, len(g))
+    assert isinstance(g, Group)
+    assert 2 == len(g)
     g.create_groups('baz', 'quux')
-    eq(4, len(g))
+    assert 4 == len(g)
 
     # mode == 'a'
     shutil.rmtree(store)
     g = open_group(store, mode='a')
-    assert_is_instance(g, Group)
-    assert_is_instance(g.store, DirectoryStore)
-    eq(0, len(g))
+    assert isinstance(g, Group)
+    assert isinstance(g.store, DirectoryStore)
+    assert 0 == len(g)
     g.create_groups('foo', 'bar')
-    eq(2, len(g))
-    with assert_raises(ValueError):
+    assert 2 == len(g)
+    with pytest.raises(ValueError):
         open_group('data/array.zarr', mode='a')
 
     # mode in 'w-', 'x'
     for mode in 'w-', 'x':
         shutil.rmtree(store)
         g = open_group(store, mode=mode)
-        assert_is_instance(g, Group)
-        assert_is_instance(g.store, DirectoryStore)
-        eq(0, len(g))
+        assert isinstance(g, Group)
+        assert isinstance(g.store, DirectoryStore)
+        assert 0 == len(g)
         g.create_groups('foo', 'bar')
-        eq(2, len(g))
-        with assert_raises(ValueError):
+        assert 2 == len(g)
+        with pytest.raises(ValueError):
             open_group(store, mode=mode)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             open_group('data/array.zarr', mode=mode)
 
     # open with path
     g = open_group(store, path='foo/bar')
-    assert_is_instance(g, Group)
-    eq('foo/bar', g.path)
+    assert isinstance(g, Group)
+    assert 'foo/bar' == g.path
 
 
 def test_group_completions():
@@ -1135,12 +1140,12 @@ def test_group_key_completions():
 
 
 def _check_tree(g, expect_bytes, expect_text):
-    eq(expect_bytes, bytes(g.tree()))
-    eq(expect_text, text_type(g.tree()))
+    assert expect_bytes == bytes(g.tree())
+    assert expect_text == text_type(g.tree())
     expect_repr = expect_text
     if PY2:  # pragma: py3 no cover
         expect_repr = expect_bytes
-    eq(expect_repr, repr(g.tree()))
+    assert expect_repr == repr(g.tree())
     # test _repr_html_ lightly
     # noinspection PyProtectedMember
     html = g.tree()._repr_html_().strip()

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -905,7 +905,7 @@ class TestGroupWithDBMStoreBerkeleyDB(TestGroup):
 
 try:
     import lmdb
-except ImportError:
+except ImportError:  # pragma: no cover
     lmdb = None
 
 

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -4,64 +4,65 @@ from __future__ import absolute_import, print_function, division
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from nose.tools import assert_raises, eq_ as eq
+import pytest
 
 
-from zarr.indexing import (normalize_integer_selection, replace_ellipsis, oindex, oindex_set)
+from zarr.indexing import (normalize_integer_selection, replace_ellipsis, oindex,
+                           oindex_set)
 import zarr
 
 
 def test_normalize_integer_selection():
 
-    eq(1, normalize_integer_selection(1, 100))
-    eq(99, normalize_integer_selection(-1, 100))
-    with assert_raises(IndexError):
+    assert 1 == normalize_integer_selection(1, 100)
+    assert 99 == normalize_integer_selection(-1, 100)
+    with pytest.raises(IndexError):
         normalize_integer_selection(100, 100)
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         normalize_integer_selection(1000, 100)
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         normalize_integer_selection(-1000, 100)
 
 
 def test_replace_ellipsis():
 
     # 1D, single item
-    eq((0,), replace_ellipsis(0, (100,)))
+    assert (0,) == replace_ellipsis(0, (100,))
 
     # 1D
-    eq((slice(None),), replace_ellipsis(Ellipsis, (100,)))
-    eq((slice(None),), replace_ellipsis(slice(None), (100,)))
-    eq((slice(None, 100),), replace_ellipsis(slice(None, 100), (100,)))
-    eq((slice(0, None),), replace_ellipsis(slice(0, None), (100,)))
-    eq((slice(None),), replace_ellipsis((slice(None), Ellipsis), (100,)))
-    eq((slice(None),), replace_ellipsis((Ellipsis, slice(None)), (100,)))
+    assert (slice(None),) == replace_ellipsis(Ellipsis, (100,))
+    assert (slice(None),) == replace_ellipsis(slice(None), (100,))
+    assert (slice(None, 100),) == replace_ellipsis(slice(None, 100), (100,))
+    assert (slice(0, None),) == replace_ellipsis(slice(0, None), (100,))
+    assert (slice(None),) == replace_ellipsis((slice(None), Ellipsis), (100,))
+    assert (slice(None),) == replace_ellipsis((Ellipsis, slice(None)), (100,))
 
     # 2D, single item
-    eq((0, 0), replace_ellipsis((0, 0), (100, 100)))
-    eq((-1, 1), replace_ellipsis((-1, 1), (100, 100)))
+    assert (0, 0) == replace_ellipsis((0, 0), (100, 100))
+    assert (-1, 1) == replace_ellipsis((-1, 1), (100, 100))
 
     # 2D, single col/row
-    eq((0, slice(None)), replace_ellipsis((0, slice(None)), (100, 100)))
-    eq((0, slice(None)), replace_ellipsis((0,), (100, 100)))
-    eq((slice(None), 0), replace_ellipsis((slice(None), 0), (100, 100)))
+    assert (0, slice(None)) == replace_ellipsis((0, slice(None)), (100, 100))
+    assert (0, slice(None)) == replace_ellipsis((0,), (100, 100))
+    assert (slice(None), 0) == replace_ellipsis((slice(None), 0), (100, 100))
 
     # 2D slice
-    eq((slice(None), slice(None)),
-       replace_ellipsis(Ellipsis, (100, 100)))
-    eq((slice(None), slice(None)),
-       replace_ellipsis(slice(None), (100, 100)))
-    eq((slice(None), slice(None)),
-       replace_ellipsis((slice(None), slice(None)), (100, 100)))
-    eq((slice(None), slice(None)),
-       replace_ellipsis((Ellipsis, slice(None)), (100, 100)))
-    eq((slice(None), slice(None)),
-       replace_ellipsis((slice(None), Ellipsis), (100, 100)))
-    eq((slice(None), slice(None)),
-       replace_ellipsis((slice(None), Ellipsis, slice(None)), (100, 100)))
-    eq((slice(None), slice(None)),
-       replace_ellipsis((Ellipsis, slice(None), slice(None)), (100, 100)))
-    eq((slice(None), slice(None)),
-       replace_ellipsis((slice(None), slice(None), Ellipsis), (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis(Ellipsis, (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis(slice(None), (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis((slice(None), slice(None)), (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis((Ellipsis, slice(None)), (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis((slice(None), Ellipsis), (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis((slice(None), Ellipsis, slice(None)), (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis((Ellipsis, slice(None), slice(None)), (100, 100)))
+    assert ((slice(None), slice(None)) ==
+            replace_ellipsis((slice(None), slice(None), Ellipsis), (100, 100)))
 
 
 def test_get_basic_selection_0d():
@@ -73,8 +74,8 @@ def test_get_basic_selection_0d():
 
     assert_array_equal(a, z.get_basic_selection(Ellipsis))
     assert_array_equal(a, z[...])
-    eq(42, z.get_basic_selection(()))
-    eq(42, z[()])
+    assert 42 == z.get_basic_selection(())
+    assert 42 == z[()]
 
     # test out param
     b = np.zeros_like(a)
@@ -88,12 +89,12 @@ def test_get_basic_selection_0d():
     z[()] = value
     assert_array_equal(a, z.get_basic_selection(Ellipsis))
     assert_array_equal(a, z[...])
-    eq(a[()], z.get_basic_selection(()))
-    eq(a[()], z[()])
-    eq(b'aaa', z.get_basic_selection((), fields='foo'))
-    eq(b'aaa', z['foo'])
-    eq(a[['foo', 'bar']], z.get_basic_selection((), fields=['foo', 'bar']))
-    eq(a[['foo', 'bar']], z['foo', 'bar'])
+    assert a[()] == z.get_basic_selection(())
+    assert a[()] == z[()]
+    assert b'aaa' == z.get_basic_selection((), fields='foo')
+    assert b'aaa' == z['foo']
+    assert a[['foo', 'bar']] == z.get_basic_selection((), fields=['foo', 'bar'])
+    assert a[['foo', 'bar']] == z['foo', 'bar']
     # test out param
     b = np.zeros_like(a)
     z.get_basic_selection(Ellipsis, out=b)
@@ -201,9 +202,9 @@ def test_get_basic_selection_1d():
         [0, 1],  # fancy indexing
     ]
     for selection in bad_selections:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.get_basic_selection(selection)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[selection]
 
 
@@ -277,9 +278,9 @@ def test_get_basic_selection_2d():
         (slice(None), [0, 1]),
     ]
     for selection in bad_selections:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.get_basic_selection(selection)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z[selection]
 
 
@@ -316,17 +317,17 @@ def test_set_basic_selection_0d():
     assert_array_equal(a, z)
     # with fields
     z.set_basic_selection(Ellipsis, v['foo'], fields='foo')
-    eq(v['foo'], z['foo'])
-    eq(a['bar'], z['bar'])
-    eq(a['baz'], z['baz'])
+    assert v['foo'] == z['foo']
+    assert a['bar'] == z['bar']
+    assert a['baz'] == z['baz']
     z['bar'] = v['bar']
-    eq(v['foo'], z['foo'])
-    eq(v['bar'], z['bar'])
-    eq(a['baz'], z['baz'])
+    assert v['foo'] == z['foo']
+    assert v['bar'] == z['bar']
+    assert a['baz'] == z['baz']
     # multiple field assignment not supported
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.set_basic_selection(Ellipsis, v[['foo', 'bar']], fields=['foo', 'bar'])
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z[..., 'foo', 'bar'] = v[['foo', 'bar']]
 
 
@@ -353,11 +354,11 @@ def test_get_orthogonal_selection_1d_bool():
         _test_get_orthogonal_selection(a, z, ix)
 
     # test errors
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.oindex[np.zeros(50, dtype=bool)]  # too short
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.oindex[np.zeros(2000, dtype=bool)]  # too long
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.oindex[[[True, False], [False, True]]]  # too many dimensions
 
 
@@ -398,9 +399,9 @@ def test_get_orthogonal_selection_1d_int():
         [[2, 4], [6, 8]],  # too many dimensions
     ]
     for selection in bad_selections:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.get_orthogonal_selection(selection)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.oindex[selection]
 
 
@@ -461,9 +462,9 @@ def test_get_orthogonal_selection_2d():
         _test_get_orthogonal_selection(a, z, selection)
 
     for selection in basic_selections_2d_bad:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.get_orthogonal_selection(selection)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.oindex[selection]
 
 
@@ -766,9 +767,9 @@ def test_get_coordinate_selection_1d():
         [-(a.shape[0] + 1)],  # out of bounds
     ]
     for selection in bad_selections:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.get_coordinate_selection(selection)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.vindex[selection]
 
 
@@ -816,16 +817,16 @@ def test_get_coordinate_selection_2d():
                     [1, 0, 0]])
     _test_get_coordinate_selection(a, z, (ix0, ix1))
 
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         selection = slice(5, 15), [1, 2, 3]
         z.get_coordinate_selection(selection)
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         selection = [1, 2, 3], slice(5, 15)
         z.get_coordinate_selection(selection)
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         selection = Ellipsis, [1, 2, 3]
         z.get_coordinate_selection(selection)
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         selection = Ellipsis
         z.get_coordinate_selection(selection)
 
@@ -864,9 +865,9 @@ def test_set_coordinate_selection_1d():
     _test_set_coordinate_selection(v, a, z, ix)
 
     for selection in coordinate_selections_1d_bad:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.set_coordinate_selection(selection, 42)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.vindex[selection] = 42
 
 
@@ -948,9 +949,9 @@ def test_get_mask_selection_1d():
         [[True, False], [False, True]],  # too many dimensions
     ]
     for selection in bad_selections:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.get_mask_selection(selection)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.vindex[selection]
 
 
@@ -969,11 +970,11 @@ def test_get_mask_selection_2d():
         _test_get_mask_selection(a, z, ix)
 
     # test errors
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.vindex[np.zeros((1000, 5), dtype=bool)]  # too short
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.vindex[np.zeros((2000, 10), dtype=bool)]  # too long
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.vindex[[True, False]]  # wrong no. dimensions
 
 
@@ -1002,9 +1003,9 @@ def test_set_mask_selection_1d():
         _test_set_mask_selection(v, a, z, ix)
 
     for selection in mask_selections_1d_bad:
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.set_mask_selection(selection, 42)
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             z.vindex[selection] = 42
 
 
@@ -1039,7 +1040,7 @@ def test_get_selection_out():
         z.get_basic_selection(selection, out=out)
         assert_array_equal(expect, out[:])
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         z.get_basic_selection(Ellipsis, out=[])
 
     # orthogonal selections
@@ -1200,9 +1201,9 @@ def test_get_selections_with_fields():
             assert_array_equal(expect, actual)
 
     # missing/bad fields
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.get_basic_selection(Ellipsis, fields=['notafield'])
-    with assert_raises(IndexError):
+    with pytest.raises(IndexError):
         z.get_basic_selection(Ellipsis, fields=slice(None))
 
 
@@ -1229,22 +1230,23 @@ def test_set_selections_with_fields():
 
     for fields in fields_fixture:
 
-        # currently multi-field assignment is not supported in numpy, so we won't support it either
+        # currently multi-field assignment is not supported in numpy, so we won't support
+        # it either
         if isinstance(fields, list) and len(fields) > 1:
-            with assert_raises(IndexError):
+            with pytest.raises(IndexError):
                 z.set_basic_selection(Ellipsis, v, fields=fields)
-            with assert_raises(IndexError):
+            with pytest.raises(IndexError):
                 z.set_orthogonal_selection([0, 2], v, fields=fields)
-            with assert_raises(IndexError):
+            with pytest.raises(IndexError):
                 z.set_coordinate_selection([0, 2], v, fields=fields)
-            with assert_raises(IndexError):
+            with pytest.raises(IndexError):
                 z.set_mask_selection([True, False, True], v, fields=fields)
 
         else:
 
             if isinstance(fields, list) and len(fields) == 1:
-                # work around numpy does not support multi-field assignment even if there is only
-                # one field
+                # work around numpy does not support multi-field assignment even if there
+                # is only one field
                 key = fields[0]
             elif isinstance(fields, list) and len(fields) == 0:
                 # work around numpy ambiguity about what is a field selection

--- a/zarr/tests/test_info.py
+++ b/zarr/tests/test_info.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import, print_function, division
 
 
-from nose.tools import assert_list_equal
-
-
 import zarr
 import numcodecs
 
@@ -24,7 +21,7 @@ def test_info():
         'Type', 'Read-only', 'Synchronizer type', 'Store type', 'Chunk store type',
         'No. members', 'No. arrays', 'No. groups', 'Arrays', 'Groups', 'Name'
     ])
-    assert_list_equal(expected_keys, keys)
+    assert expected_keys == keys
 
     # test array info
     items = z.info_items()
@@ -34,4 +31,4 @@ def test_info():
         'Compressor', 'Synchronizer type', 'Store type', 'Chunk store type', 'No. bytes',
         'No. bytes stored', 'Storage ratio', 'Chunks initialized', 'Name'
     ])
-    assert_list_equal(expected_keys, keys)
+    assert expected_keys == keys

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -4,8 +4,8 @@ import json
 import base64
 
 
-from nose.tools import eq_ as eq, assert_is_none, assert_raises
 import numpy as np
+import pytest
 
 
 from zarr.compat import binary_type, text_type, PY2
@@ -15,14 +15,14 @@ from zarr.errors import MetadataError
 from zarr.codecs import Delta, Zlib, Blosc
 
 
-def assert_json_eq(expect, actual):
+def assert_json_equal(expect, actual):
     if isinstance(expect, binary_type):  # pragma: py3 no cover
         expect = text_type(expect, 'ascii')
     if isinstance(actual, binary_type):
         actual = text_type(actual, 'ascii')
     ej = json.loads(expect)
     aj = json.loads(actual)
-    eq(ej, aj)
+    assert ej == aj
 
 
 def test_encode_decode_array_1():
@@ -50,18 +50,18 @@ def test_encode_decode_array_1():
 
     # test encoding
     meta_enc = encode_array_metadata(meta)
-    assert_json_eq(meta_json, meta_enc)
+    assert_json_equal(meta_json, meta_enc)
 
     # test decoding
     meta_dec = decode_array_metadata(meta_enc)
-    eq(ZARR_FORMAT, meta_dec['zarr_format'])
-    eq(meta['shape'], meta_dec['shape'])
-    eq(meta['chunks'], meta_dec['chunks'])
-    eq(meta['dtype'], meta_dec['dtype'])
-    eq(meta['compressor'], meta_dec['compressor'])
-    eq(meta['order'], meta_dec['order'])
-    assert_is_none(meta_dec['fill_value'])
-    assert_is_none(meta_dec['filters'])
+    assert ZARR_FORMAT == meta_dec['zarr_format']
+    assert meta['shape'] == meta_dec['shape']
+    assert meta['chunks'] == meta_dec['chunks']
+    assert meta['dtype'] == meta_dec['dtype']
+    assert meta['compressor'] == meta_dec['compressor']
+    assert meta['order'] == meta_dec['order']
+    assert meta_dec['fill_value'] is None
+    assert meta_dec['filters'] is None
 
 
 def test_encode_decode_array_2():
@@ -100,19 +100,19 @@ def test_encode_decode_array_2():
 
     # test encoding
     meta_enc = encode_array_metadata(meta)
-    assert_json_eq(meta_json, meta_enc)
+    assert_json_equal(meta_json, meta_enc)
 
     # test decoding
     meta_dec = decode_array_metadata(meta_enc)
-    eq(ZARR_FORMAT, meta_dec['zarr_format'])
-    eq(meta['shape'], meta_dec['shape'])
-    eq(meta['chunks'], meta_dec['chunks'])
-    eq(meta['dtype'], meta_dec['dtype'])
-    eq(meta['compressor'], meta_dec['compressor'])
-    eq(meta['order'], meta_dec['order'])
+    assert ZARR_FORMAT == meta_dec['zarr_format']
+    assert meta['shape'] == meta_dec['shape']
+    assert meta['chunks'] == meta_dec['chunks']
+    assert meta['dtype'] == meta_dec['dtype']
+    assert meta['compressor'] == meta_dec['compressor']
+    assert meta['order'] == meta_dec['order']
     np_fill_value = np.array(meta['fill_value'], dtype=meta['dtype'])[()]
-    eq(np_fill_value, meta_dec['fill_value'])
-    eq([df.get_config()], meta_dec['filters'])
+    assert np_fill_value == meta_dec['fill_value']
+    assert [df.get_config()] == meta_dec['filters']
 
 
 def test_encode_decode_fill_values_nan():
@@ -148,7 +148,7 @@ def test_encode_decode_fill_values_nan():
 
         # test encoding
         meta_enc = encode_array_metadata(meta)
-        assert_json_eq(meta_json, meta_enc)
+        assert_json_equal(meta_json, meta_enc)
 
         # test decoding
         meta_dec = decode_array_metadata(meta_enc)
@@ -191,13 +191,13 @@ def test_encode_decode_fill_values_bytes():
         }''' % (s, ZARR_FORMAT)
 
         # test encoding
-        assert_json_eq(meta_json, meta_enc)
+        assert_json_equal(meta_json, meta_enc)
 
         # test decoding
         meta_dec = decode_array_metadata(meta_enc)
         actual = meta_dec['fill_value']
         expect = np.array(v, dtype=dtype)[()]
-        eq(expect, actual)
+        assert expect == actual
 
 
 def test_decode_array_unsupported_format():
@@ -212,7 +212,7 @@ def test_decode_array_unsupported_format():
         "fill_value": null,
         "order": "C"
     }''' % (ZARR_FORMAT - 1)
-    with assert_raises(MetadataError):
+    with pytest.raises(MetadataError):
         decode_array_metadata(meta_json)
 
 
@@ -222,7 +222,7 @@ def test_decode_array_missing_fields():
     meta_json = '''{
         "zarr_format": %s
     }''' % ZARR_FORMAT
-    with assert_raises(MetadataError):
+    with pytest.raises(MetadataError):
         decode_array_metadata(meta_json)
 
 
@@ -233,7 +233,7 @@ def test_encode_decode_dtype():
         s = json.dumps(e)  # check JSON serializable
         o = json.loads(s)
         d = decode_dtype(o)
-        eq(np.dtype(dt), d)
+        assert np.dtype(dt) == d
 
 
 def test_decode_group():
@@ -243,11 +243,11 @@ def test_decode_group():
         "zarr_format": %s
     }''' % ZARR_FORMAT
     meta = decode_group_metadata(b)
-    eq(ZARR_FORMAT, meta['zarr_format'])
+    assert ZARR_FORMAT == meta['zarr_format']
 
     # unsupported format
     b = '''{
         "zarr_format": %s
     }''' % (ZARR_FORMAT - 1)
-    with assert_raises(MetadataError):
+    with pytest.raises(MetadataError):
         decode_group_metadata(b)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -12,8 +12,6 @@ import os
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose import SkipTest
-from nose.tools import assert_raises, eq_ as eq, assert_is_none
 import pytest
 
 
@@ -43,12 +41,12 @@ class StoreTests(object):
 
         # test __contains__, __getitem__, __setitem__
         assert 'foo' not in store
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             # noinspection PyStatementEffect
             store['foo']
         store['foo'] = b'bar'
         assert 'foo' in store
-        eq(b'bar', store['foo'])
+        assert b'bar' == store['foo']
 
         # test __delitem__ (optional)
         try:
@@ -57,10 +55,10 @@ class StoreTests(object):
             pass
         else:
             assert 'foo' not in store
-            with assert_raises(KeyError):
+            with pytest.raises(KeyError):
                 # noinspection PyStatementEffect
                 store['foo']
-            with assert_raises(KeyError):
+            with pytest.raises(KeyError):
                 # noinspection PyStatementEffect
                 del store['foo']
 
@@ -85,7 +83,7 @@ class StoreTests(object):
         v = store.pop('baz')
         assert v == b'qux'
         assert len(store) == 0
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             store.pop('xxx')
 
     def test_writeable_values(self):
@@ -102,18 +100,18 @@ class StoreTests(object):
         assert 'foo' not in store
         assert 'baz' not in store
         store.update(foo=b'bar', baz=b'quux')
-        eq(b'bar', store['foo'])
-        eq(b'quux', store['baz'])
+        assert b'bar' == store['foo']
+        assert b'quux' == store['baz']
 
     def test_iterators(self):
         store = self.create_store()
 
         # test iterator methods on empty store
-        eq(0, len(store))
-        eq(set(), set(store))
-        eq(set(), set(store.keys()))
-        eq(set(), set(store.values()))
-        eq(set(), set(store.items()))
+        assert 0 == len(store)
+        assert set() == set(store)
+        assert set() == set(store.keys())
+        assert set() == set(store.values())
+        assert set() == set(store.items())
 
         # setup some values
         store['a'] = b'aaa'
@@ -122,42 +120,42 @@ class StoreTests(object):
         store['c/e/f'] = b'fff'
 
         # test iterators on store with data
-        eq(4, len(store))
-        eq({'a', 'b', 'c/d', 'c/e/f'}, set(store))
-        eq({'a', 'b', 'c/d', 'c/e/f'}, set(store.keys()))
-        eq({b'aaa', b'bbb', b'ddd', b'fff'}, set(store.values()))
-        eq({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')},
-           set(store.items()))
+        assert 4 == len(store)
+        assert {'a', 'b', 'c/d', 'c/e/f'} == set(store)
+        assert {'a', 'b', 'c/d', 'c/e/f'} == set(store.keys())
+        assert {b'aaa', b'bbb', b'ddd', b'fff'} == set(store.values())
+        assert ({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')} ==
+                set(store.items()))
 
     def test_pickle(self):
         store = self.create_store()
         store['foo'] = b'bar'
         store['baz'] = b'quux'
         store2 = pickle.loads(pickle.dumps(store))
-        eq(len(store), len(store2))
-        eq(sorted(store.keys()), sorted(store2.keys()))
-        eq(b'bar', store2['foo'])
-        eq(b'quux', store2['baz'])
+        assert len(store) == len(store2)
+        assert sorted(store.keys()) == sorted(store2.keys())
+        assert b'bar' == store2['foo']
+        assert b'quux' == store2['baz']
 
     def test_getsize(self):
         store = self.create_store()
         if isinstance(store, dict) or hasattr(store, 'getsize'):
-            eq(0, getsize(store))
+            assert 0 == getsize(store)
             store['foo'] = b'x'
-            eq(1, getsize(store))
-            eq(1, getsize(store, 'foo'))
+            assert 1 == getsize(store)
+            assert 1 == getsize(store, 'foo')
             store['bar'] = b'yy'
-            eq(3, getsize(store))
-            eq(2, getsize(store, 'bar'))
+            assert 3 == getsize(store)
+            assert 2 == getsize(store, 'bar')
             store['baz'] = bytearray(b'zzz')
-            eq(6, getsize(store))
-            eq(3, getsize(store, 'baz'))
+            assert 6 == getsize(store)
+            assert 3 == getsize(store, 'baz')
             store['quux'] = array.array('B', b'zzzz')
-            eq(10, getsize(store))
-            eq(4, getsize(store, 'quux'))
+            assert 10 == getsize(store)
+            assert 4 == getsize(store, 'quux')
             store['spong'] = np.frombuffer(b'zzzzz', dtype='u1')
-            eq(15, getsize(store))
-            eq(5, getsize(store, 'spong'))
+            assert 15 == getsize(store)
+            assert 5 == getsize(store, 'spong')
 
     # noinspection PyStatementEffect
     def test_hierarchy(self):
@@ -182,44 +180,44 @@ class StoreTests(object):
         assert 'c/d/x' not in store
 
         # check __getitem__
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             store['c']
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             store['c/e']
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             store['c/d/x']
 
         # test getsize (optional)
         if hasattr(store, 'getsize'):
-            eq(6, store.getsize())
-            eq(3, store.getsize('a'))
-            eq(3, store.getsize('b'))
-            eq(3, store.getsize('c'))
-            eq(3, store.getsize('c/d'))
-            eq(6, store.getsize('c/e'))
-            eq(3, store.getsize('c/e/f'))
-            eq(3, store.getsize('c/e/g'))
+            assert 6 == store.getsize()
+            assert 3 == store.getsize('a')
+            assert 3 == store.getsize('b')
+            assert 3 == store.getsize('c')
+            assert 3 == store.getsize('c/d')
+            assert 6 == store.getsize('c/e')
+            assert 3 == store.getsize('c/e/f')
+            assert 3 == store.getsize('c/e/g')
             # non-existent paths
-            eq(0, store.getsize('x'))
-            eq(0, store.getsize('a/x'))
-            eq(0, store.getsize('c/x'))
-            eq(0, store.getsize('c/x/y'))
-            eq(0, store.getsize('c/d/y'))
-            eq(0, store.getsize('c/d/y/z'))
+            assert 0 == store.getsize('x')
+            assert 0 == store.getsize('a/x')
+            assert 0 == store.getsize('c/x')
+            assert 0 == store.getsize('c/x/y')
+            assert 0 == store.getsize('c/d/y')
+            assert 0 == store.getsize('c/d/y/z')
 
         # test listdir (optional)
         if hasattr(store, 'listdir'):
-            eq({'a', 'b', 'c'}, set(store.listdir()))
-            eq({'d', 'e'}, set(store.listdir('c')))
-            eq({'f', 'g'}, set(store.listdir('c/e')))
+            assert {'a', 'b', 'c'} == set(store.listdir())
+            assert {'d', 'e'} == set(store.listdir('c'))
+            assert {'f', 'g'} == set(store.listdir('c/e'))
             # no exception raised if path does not exist or is leaf
-            eq([], store.listdir('x'))
-            eq([], store.listdir('a/x'))
-            eq([], store.listdir('c/x'))
-            eq([], store.listdir('c/x/y'))
-            eq([], store.listdir('c/d/y'))
-            eq([], store.listdir('c/d/y/z'))
-            eq([], store.listdir('c/e/f'))
+            assert [] == store.listdir('x')
+            assert [] == store.listdir('a/x')
+            assert [] == store.listdir('c/x')
+            assert [] == store.listdir('c/x/y')
+            assert [] == store.listdir('c/d/y')
+            assert [] == store.listdir('c/d/y/z')
+            assert [] == store.listdir('c/e/f')
 
         # test rename (optional)
         if hasattr(store, 'rename'):
@@ -300,12 +298,12 @@ class StoreTests(object):
         # check metadata
         assert array_meta_key in store
         meta = decode_array_metadata(store[array_meta_key])
-        eq(ZARR_FORMAT, meta['zarr_format'])
-        eq((1000,), meta['shape'])
-        eq((100,), meta['chunks'])
-        eq(np.dtype(None), meta['dtype'])
-        eq(default_compressor.get_config(), meta['compressor'])
-        assert_is_none(meta['fill_value'])
+        assert ZARR_FORMAT == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunks']
+        assert np.dtype(None) == meta['dtype']
+        assert default_compressor.get_config() == meta['compressor']
+        assert meta['fill_value'] is None
 
     def test_init_array_overwrite(self):
         # setup
@@ -321,7 +319,7 @@ class StoreTests(object):
         )
 
         # don't overwrite (default)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_array(store, shape=1000, chunks=100)
 
         # do overwrite
@@ -333,10 +331,10 @@ class StoreTests(object):
         else:
             assert array_meta_key in store
             meta = decode_array_metadata(store[array_meta_key])
-            eq(ZARR_FORMAT, meta['zarr_format'])
-            eq((1000,), meta['shape'])
-            eq((100,), meta['chunks'])
-            eq(np.dtype('i4'), meta['dtype'])
+            assert ZARR_FORMAT == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunks']
+            assert np.dtype('i4') == meta['dtype']
 
     def test_init_array_path(self):
         path = 'foo/bar'
@@ -347,12 +345,12 @@ class StoreTests(object):
         key = path + '/' + array_meta_key
         assert key in store
         meta = decode_array_metadata(store[key])
-        eq(ZARR_FORMAT, meta['zarr_format'])
-        eq((1000,), meta['shape'])
-        eq((100,), meta['chunks'])
-        eq(np.dtype(None), meta['dtype'])
-        eq(default_compressor.get_config(), meta['compressor'])
-        assert_is_none(meta['fill_value'])
+        assert ZARR_FORMAT == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunks']
+        assert np.dtype(None) == meta['dtype']
+        assert default_compressor.get_config() == meta['compressor']
+        assert meta['fill_value'] is None
 
     def test_init_array_overwrite_path(self):
         # setup
@@ -369,7 +367,7 @@ class StoreTests(object):
         store[path + '/' + array_meta_key] = encode_array_metadata(meta)
 
         # don't overwrite
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_array(store, shape=1000, chunks=100, path=path)
 
         # do overwrite
@@ -384,10 +382,10 @@ class StoreTests(object):
             assert (path + '/' + array_meta_key) in store
             # should have been overwritten
             meta = decode_array_metadata(store[path + '/' + array_meta_key])
-            eq(ZARR_FORMAT, meta['zarr_format'])
-            eq((1000,), meta['shape'])
-            eq((100,), meta['chunks'])
-            eq(np.dtype('i4'), meta['dtype'])
+            assert ZARR_FORMAT == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunks']
+            assert np.dtype('i4') == meta['dtype']
 
     def test_init_array_overwrite_group(self):
         # setup
@@ -396,7 +394,7 @@ class StoreTests(object):
         store[path + '/' + group_meta_key] = encode_group_metadata()
 
         # don't overwrite
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_array(store, shape=1000, chunks=100, path=path)
 
         # do overwrite
@@ -409,10 +407,10 @@ class StoreTests(object):
             assert (path + '/' + group_meta_key) not in store
             assert (path + '/' + array_meta_key) in store
             meta = decode_array_metadata(store[path + '/' + array_meta_key])
-            eq(ZARR_FORMAT, meta['zarr_format'])
-            eq((1000,), meta['shape'])
-            eq((100,), meta['chunks'])
-            eq(np.dtype('i4'), meta['dtype'])
+            assert ZARR_FORMAT == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunks']
+            assert np.dtype('i4') == meta['dtype']
 
     def test_init_array_overwrite_chunk_store(self):
         # setup
@@ -431,7 +429,7 @@ class StoreTests(object):
         chunk_store['1'] = b'bbb'
 
         # don't overwrite (default)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_array(store, shape=1000, chunks=100, chunk_store=chunk_store)
 
         # do overwrite
@@ -443,10 +441,10 @@ class StoreTests(object):
         else:
             assert array_meta_key in store
             meta = decode_array_metadata(store[array_meta_key])
-            eq(ZARR_FORMAT, meta['zarr_format'])
-            eq((1000,), meta['shape'])
-            eq((100,), meta['chunks'])
-            eq(np.dtype('i4'), meta['dtype'])
+            assert ZARR_FORMAT == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunks']
+            assert np.dtype('i4') == meta['dtype']
             assert '0' not in chunk_store
             assert '1' not in chunk_store
 
@@ -454,7 +452,7 @@ class StoreTests(object):
         store = self.create_store()
         init_array(store, shape=1000, chunks=100, compressor='none')
         meta = decode_array_metadata(store[array_meta_key])
-        assert_is_none(meta['compressor'])
+        assert meta['compressor'] is None
 
     def test_init_group(self):
         store = self.create_store()
@@ -463,7 +461,7 @@ class StoreTests(object):
         # check metadata
         assert group_meta_key in store
         meta = decode_group_metadata(store[group_meta_key])
-        eq(ZARR_FORMAT, meta['zarr_format'])
+        assert ZARR_FORMAT == meta['zarr_format']
 
     def test_init_group_overwrite(self):
         # setup
@@ -479,7 +477,7 @@ class StoreTests(object):
         )
 
         # don't overwrite array (default)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_group(store)
 
         # do overwrite
@@ -491,10 +489,10 @@ class StoreTests(object):
             assert array_meta_key not in store
             assert group_meta_key in store
             meta = decode_group_metadata(store[group_meta_key])
-            eq(ZARR_FORMAT, meta['zarr_format'])
+            assert ZARR_FORMAT == meta['zarr_format']
 
         # don't overwrite group
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_group(store)
 
     def test_init_group_overwrite_path(self):
@@ -512,7 +510,7 @@ class StoreTests(object):
         store[path + '/' + array_meta_key] = encode_array_metadata(meta)
 
         # don't overwrite
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_group(store, path=path)
 
         # do overwrite
@@ -527,7 +525,7 @@ class StoreTests(object):
             assert (path + '/' + group_meta_key) in store
             # should have been overwritten
             meta = decode_group_metadata(store[path + '/' + group_meta_key])
-            eq(ZARR_FORMAT, meta['zarr_format'])
+            assert ZARR_FORMAT == meta['zarr_format']
 
     def test_init_group_overwrite_chunk_store(self):
         # setup
@@ -546,7 +544,7 @@ class StoreTests(object):
         chunk_store['baz'] = b'quux'
 
         # don't overwrite array (default)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_group(store, chunk_store=chunk_store)
 
         # do overwrite
@@ -558,12 +556,12 @@ class StoreTests(object):
             assert array_meta_key not in store
             assert group_meta_key in store
             meta = decode_group_metadata(store[group_meta_key])
-            eq(ZARR_FORMAT, meta['zarr_format'])
+            assert ZARR_FORMAT == meta['zarr_format']
             assert 'foo' not in chunk_store
             assert 'baz' not in chunk_store
 
         # don't overwrite group
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             init_group(store)
 
 
@@ -581,24 +579,24 @@ def setdel_hierarchy_checks(store):
     # check __setitem__ and __delitem__ blocked by leaf
 
     store['a/b'] = b'aaa'
-    with assert_raises(KeyError):
+    with pytest.raises(KeyError):
         store['a/b/c'] = b'xxx'
-    with assert_raises(KeyError):
+    with pytest.raises(KeyError):
         del store['a/b/c']
 
     store['d'] = b'ddd'
-    with assert_raises(KeyError):
+    with pytest.raises(KeyError):
         store['d/e/f'] = b'xxx'
-    with assert_raises(KeyError):
+    with pytest.raises(KeyError):
         del store['d/e/f']
 
     # test __setitem__ overwrite level
     store['x/y/z'] = b'xxx'
     store['x/y'] = b'yyy'
-    eq(b'yyy', store['x/y'])
+    assert b'yyy' == store['x/y']
     assert 'x/y/z' not in store
     store['x'] = b'zzz'
-    eq(b'zzz', store['x'])
+    assert b'zzz' == store['x']
     assert 'x/y' not in store
 
     # test __delitem__ overwrite level
@@ -623,9 +621,9 @@ class TestDictStore(StoreTests, unittest.TestCase):
         store = self.create_store()
         store['a'] = list(range(10))
         store['b/c'] = list(range(10))
-        eq(-1, store.getsize())
-        eq(-1, store.getsize('a'))
-        eq(-1, store.getsize('b'))
+        assert -1 == store.getsize()
+        assert -1 == store.getsize('a')
+        assert -1 == store.getsize('b')
 
 
 class TestDirectoryStore(StoreTests, unittest.TestCase):
@@ -650,7 +648,7 @@ class TestDirectoryStore(StoreTests, unittest.TestCase):
 
         # test behaviour with file path
         with tempfile.NamedTemporaryFile() as f:
-            with assert_raises(ValueError):
+            with pytest.raises(ValueError):
                 DirectoryStore(f.name)
 
     def test_pickle_ext(self):
@@ -658,12 +656,12 @@ class TestDirectoryStore(StoreTests, unittest.TestCase):
         store2 = pickle.loads(pickle.dumps(store))
 
         # check path is preserved
-        eq(store.path, store2.path)
+        assert store.path == store2.path
 
         # check point to same underlying directory
         assert 'xxx' not in store
         store2['xxx'] = b'yyy'
-        eq(b'yyy', store['xxx'])
+        assert b'yyy' == store['xxx']
 
     def test_setdel(self):
         store = self.create_store()
@@ -682,13 +680,13 @@ class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
         store = self.create_store()
         # any path where last segment looks like a chunk key gets special handling
         store['0.0'] = b'xxx'
-        eq(b'xxx', store['0.0'])
-        eq(b'xxx', store['0/0'])
+        assert b'xxx' == store['0.0']
+        assert b'xxx' == store['0/0']
         store['foo/10.20.30'] = b'yyy'
-        eq(b'yyy', store['foo/10.20.30'])
-        eq(b'yyy', store['foo/10/20/30'])
+        assert b'yyy' == store['foo/10.20.30']
+        assert b'yyy' == store['foo/10/20/30']
         store['42'] = b'zzz'
-        eq(b'zzz', store['42'])
+        assert b'zzz' == store['42']
 
 
 class TestTempStore(StoreTests, unittest.TestCase):
@@ -713,9 +711,9 @@ class TestZipStore(StoreTests, unittest.TestCase):
         with ZipStore('data/store.zip', mode='w') as store:
             store['foo'] = b'bar'
         store = ZipStore('data/store.zip', mode='r')
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             store['foo'] = b'bar'
-        with assert_raises(PermissionError):
+        with pytest.raises(PermissionError):
             store.clear()
 
     def test_flush(self):
@@ -732,13 +730,13 @@ class TestZipStore(StoreTests, unittest.TestCase):
         with self.create_store() as store:
             store['foo'] = b'bar'
             store['baz'] = b'qux'
-            eq(2, len(store))
+            assert 2 == len(store)
 
     def test_pop(self):
         # override because not implemented
         store = self.create_store()
         store['foo'] = b'bar'
-        with assert_raises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             store.pop('foo')
 
 
@@ -754,7 +752,7 @@ class TestDBMStore(StoreTests, unittest.TestCase):
         with self.create_store() as store:
             store['foo'] = b'bar'
             store['baz'] = b'qux'
-            eq(2, len(store))
+            assert 2 == len(store)
 
 
 class TestDBMStoreDumb(TestDBMStore):
@@ -775,50 +773,60 @@ try:
         import gdbm
     else:  # pragma: py2 no cover
         import dbm.gnu as gdbm
-
-    class TestDBMStoreGnu(TestDBMStore):
-
-        def create_store(self):
-            path = tempfile.mktemp(suffix='.gdbm')
-            atexit.register(os.remove, path)
-            store = DBMStore(path, flag='n', open=gdbm.open, write_lock=False)
-            return store
-
 except ImportError:  # pragma: no cover
-    pass
+    gdbm = None
+
+
+@pytest.mark.skipif(gdbm is None, reason='gdbm is not installed')
+class TestDBMStoreGnu(TestDBMStore):
+
+    def create_store(self):
+        path = tempfile.mktemp(suffix='.gdbm')
+        atexit.register(os.remove, path)
+        store = DBMStore(path, flag='n', open=gdbm.open, write_lock=False)
+        return store
 
 
 if not PY2:
     try:
         import dbm.ndbm as ndbm
-
-        class TestDBMStoreNDBM(TestDBMStore):
-
-            def create_store(self):
-                path = tempfile.mktemp(suffix='.ndbm')
-                atexit.register(atexit_rmglob, path + '*')
-                store = DBMStore(path, flag='n', open=ndbm.open)
-                return store
-
     except ImportError:  # pragma: no cover
-        pass
+        ndbm = None
+
+
+    @pytest.mark.skipif(ndbm is None, reason='ndbm is not installed')
+    class TestDBMStoreNDBM(TestDBMStore):
+
+        def create_store(self):
+            path = tempfile.mktemp(suffix='.ndbm')
+            atexit.register(atexit_rmglob, path + '*')
+            store = DBMStore(path, flag='n', open=ndbm.open)
+            return store
 
 
 try:
     import bsddb3
-
-    class TestDBMStoreBerkeleyDB(TestDBMStore):
-
-        def create_store(self):
-            path = tempfile.mktemp(suffix='.dbm')
-            atexit.register(os.remove, path)
-            store = DBMStore(path, flag='n', open=bsddb3.btopen, write_lock=False)
-            return store
-
 except ImportError:  # pragma: no cover
-    pass
+    bsddb3 = None
 
 
+@pytest.mark.skipif(bsddb3 is None, reason='bsddb3 is not installed')
+class TestDBMStoreBerkeleyDB(TestDBMStore):
+
+    def create_store(self):
+        path = tempfile.mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStore(path, flag='n', open=bsddb3.btopen, write_lock=False)
+        return store
+
+
+try:
+    import lmdb
+except ImportError:
+    lmdb = None
+
+
+@pytest.mark.skipif(lmdb is None, reason='lmdb is not installed')
 class TestLMDBStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
@@ -830,17 +838,14 @@ class TestLMDBStore(StoreTests, unittest.TestCase):
             buffers = False
         else:  # pragma: py2 no cover
             buffers = True
-        try:
-            store = LMDBStore(path, buffers=buffers)
-        except ImportError:  # pragma: no cover
-            raise SkipTest('lmdb not installed')
+        store = LMDBStore(path, buffers=buffers)
         return store
 
     def test_context_manager(self):
         with self.create_store() as store:
             store['foo'] = b'bar'
             store['baz'] = b'qux'
-            eq(2, len(store))
+            assert 2 == len(store)
 
 
 class TestLRUStoreCache(StoreTests, unittest.TestCase):
@@ -1072,8 +1077,8 @@ def test_getsize():
     store['foo'] = b'aaa'
     store['bar'] = b'bbbb'
     store['baz/quux'] = b'ccccc'
-    eq(7, getsize(store))
-    eq(5, getsize(store, 'baz'))
+    assert 7 == getsize(store)
+    assert 5 == getsize(store, 'baz')
 
 
 def test_migrate_1to2():
@@ -1106,19 +1111,19 @@ def test_migrate_1to2():
     assert 'attrs' not in store
     assert attrs_key in store
     meta_migrated = decode_array_metadata(store[array_meta_key])
-    eq(2, meta_migrated['zarr_format'])
+    assert 2 == meta_migrated['zarr_format']
 
     # preserved fields
     for f in 'shape', 'chunks', 'dtype', 'fill_value', 'order':
-        eq(meta[f], meta_migrated[f])
+        assert meta[f] == meta_migrated[f]
 
     # migrate should have added empty filters field
-    assert_is_none(meta_migrated['filters'])
+    assert meta_migrated['filters'] is None
 
     # check compression and compression_opts migrated to compressor
     assert 'compression' not in meta_migrated
     assert 'compression_opts' not in meta_migrated
-    eq(meta_migrated['compressor'], Zlib(1).get_config())
+    assert meta_migrated['compressor'] == Zlib(1).get_config()
 
     # check dict compression_opts
     store = dict()
@@ -1131,8 +1136,8 @@ def test_migrate_1to2():
     meta_migrated = decode_array_metadata(store[array_meta_key])
     assert 'compression' not in meta_migrated
     assert 'compression_opts' not in meta_migrated
-    eq(meta_migrated['compressor'],
-       Blosc(cname='lz4', clevel=5, shuffle=1).get_config())
+    assert (meta_migrated['compressor'] ==
+            Blosc(cname='lz4', clevel=5, shuffle=1).get_config())
 
     # check 'none' compression is migrated to None (null in JSON)
     store = dict()
@@ -1144,7 +1149,7 @@ def test_migrate_1to2():
     meta_migrated = decode_array_metadata(store[array_meta_key])
     assert 'compression' not in meta_migrated
     assert 'compression_opts' not in meta_migrated
-    assert_is_none(meta_migrated['compressor'])
+    assert meta_migrated['compressor'] is None
 
 
 def test_format_compatibility():
@@ -1173,9 +1178,12 @@ def test_format_compatibility():
         (np.random.normal(loc=0, scale=1, size=4444).astype('f2'), 100),
         (np.random.normal(loc=0, scale=1, size=4444).astype('f4'), 100),
         (np.random.normal(loc=0, scale=1, size=4444).astype('f8'), 100),
-        (np.random.choice([b'A', b'C', b'G', b'T'], size=5555, replace=True).astype('S'), 100),
-        (np.random.choice(['foo', 'bar', 'baz', 'quux'], size=5555, replace=True).astype('U'), 100),
-        (np.random.choice([0, 1/3, 1/7, 1/9, np.nan], size=5555, replace=True).astype('f8'), 100),
+        (np.random.choice([b'A', b'C', b'G', b'T'],
+                          size=5555, replace=True).astype('S'), 100),
+        (np.random.choice(['foo', 'bar', 'baz', 'quux'],
+                          size=5555, replace=True).astype('U'), 100),
+        (np.random.choice([0, 1/3, 1/7, 1/9, np.nan],
+                          size=5555, replace=True).astype('f8'), 100),
         (np.random.randint(0, 2, size=5555, dtype=bool), 100),
         (np.arange(20000, dtype='i4').reshape(2000, 10, order='C'), (100, 3)),
         (np.arange(20000, dtype='i4').reshape(200, 100, order='F'), (100, 30)),
@@ -1207,7 +1215,8 @@ def test_format_compatibility():
 
             if path not in fixture:  # pragma: no cover
                 # store the data - should be one-time operation
-                fixture.array(path, data=arr, chunks=chunks, order=order, compressor=compressor)
+                fixture.array(path, data=arr, chunks=chunks, order=order,
+                              compressor=compressor)
 
             # setup array
             z = fixture[path]
@@ -1219,11 +1228,11 @@ def test_format_compatibility():
                 assert_array_equal(arr, z[:])
 
             # check dtype
-            eq(arr.dtype, z.dtype)
+            assert arr.dtype == z.dtype
 
             # check compressor
             if compressor is None:
-                assert_is_none(z.compressor)
+                assert z.compressor is None
             else:
-                eq(compressor.codec_id, z.compressor.codec_id)
-                eq(compressor.get_config(), z.compressor.get_config())
+                assert compressor.codec_id == z.compressor.codec_id
+                assert compressor.get_config() == z.compressor.get_config()

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -793,7 +793,6 @@ if not PY2:
     except ImportError:  # pragma: no cover
         ndbm = None
 
-
     @pytest.mark.skipif(ndbm is None, reason='ndbm is not installed')
     class TestDBMStoreNDBM(TestDBMStore):
 
@@ -822,7 +821,7 @@ class TestDBMStoreBerkeleyDB(TestDBMStore):
 
 try:
     import lmdb
-except ImportError:
+except ImportError:  # pragma: no cover
     lmdb = None
 
 

--- a/zarr/tests/test_sync.py
+++ b/zarr/tests/test_sync.py
@@ -10,7 +10,6 @@ import tempfile
 
 
 import numpy as np
-from nose.tools import eq_ as eq, assert_is_instance
 from numpy.testing import assert_array_equal
 
 
@@ -46,8 +45,8 @@ class TestAttributesProcessSynchronizer(TestAttributes):
 
 def _append(arg):
     z, i = arg
-    import numpy as np
-    x = np.empty(1000, dtype='i4')
+    import numpy
+    x = numpy.empty(1000, dtype='i4')
     x[:] = i
     shape = z.append(x)
     return shape
@@ -55,8 +54,8 @@ def _append(arg):
 
 def _set_arange(arg):
     z, i = arg
-    import numpy as np
-    x = np.arange(i*1000, (i*1000)+1000, 1)
+    import numpy
+    x = numpy.arange(i*1000, (i*1000)+1000, 1)
     z[i*1000:(i*1000)+1000] = x
     return i
 
@@ -75,7 +74,7 @@ class MixinArraySyncTests(object):
         results = pool.map(_set_arange, zip([arr] * n, range(n)), chunksize=1)
         results = sorted(results)
 
-        eq(list(range(n)), results)
+        assert list(range(n)) == results
         assert_array_equal(np.arange(n * 1000), arr[:])
 
         pool.terminate()
@@ -92,8 +91,8 @@ class MixinArraySyncTests(object):
         results = pool.map(_append, zip([arr] * n, range(n)), chunksize=1)
         results = sorted(results)
 
-        eq([((i+2)*1000,) for i in range(n)], results)
-        eq(((n+1)*1000,), arr.shape)
+        assert [((i+2)*1000,) for i in range(n)] == results
+        assert ((n+1)*1000,) == arr.shape
 
         pool.terminate()
 
@@ -109,6 +108,7 @@ class TestArrayWithThreadSynchronizer(TestArray, MixinArraySyncTests):
                      read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
 
+    # noinspection PyMethodMayBeStatic
     def create_pool(self):
         pool = ThreadPool(cpu_count())
         return pool
@@ -116,25 +116,25 @@ class TestArrayWithThreadSynchronizer(TestArray, MixinArraySyncTests):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('f710da18d45d38d4aaf2afd7fb822fdd73d02957', z.hexdigest())
+        assert 'f710da18d45d38d4aaf2afd7fb822fdd73d02957' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('1437428e69754b1e1a38bd7fc9e43669577620db', z.hexdigest())
+        assert '1437428e69754b1e1a38bd7fc9e43669577620db' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('dde44c72cc530bd6aae39b629eb15a2da627e5f9', z.hexdigest())
+        assert 'dde44c72cc530bd6aae39b629eb15a2da627e5f9' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('4c0a76fb1222498e09dcd92f7f9221d6cea8b40e', z.hexdigest())
+        assert '4c0a76fb1222498e09dcd92f7f9221d6cea8b40e' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('05b0663ffe1785f38d3a459dec17e57a18f254af', z.hexdigest())
+        assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
 
 
 class TestArrayWithProcessSynchronizer(TestArray, MixinArraySyncTests):
@@ -152,6 +152,7 @@ class TestArrayWithProcessSynchronizer(TestArray, MixinArraySyncTests):
         return Array(store, synchronizer=synchronizer, read_only=read_only,
                      cache_metadata=cache_metadata, cache_attrs=cache_attrs)
 
+    # noinspection PyMethodMayBeStatic
     def create_pool(self):
         pool = ProcessPool(processes=cpu_count())
         return pool
@@ -159,25 +160,25 @@ class TestArrayWithProcessSynchronizer(TestArray, MixinArraySyncTests):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
-        eq('f710da18d45d38d4aaf2afd7fb822fdd73d02957', z.hexdigest())
+        assert 'f710da18d45d38d4aaf2afd7fb822fdd73d02957' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='f4')
-        eq('1437428e69754b1e1a38bd7fc9e43669577620db', z.hexdigest())
+        assert '1437428e69754b1e1a38bd7fc9e43669577620db' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='i4')
-        eq('dde44c72cc530bd6aae39b629eb15a2da627e5f9', z.hexdigest())
+        assert 'dde44c72cc530bd6aae39b629eb15a2da627e5f9' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        eq('4c0a76fb1222498e09dcd92f7f9221d6cea8b40e', z.hexdigest())
+        assert '4c0a76fb1222498e09dcd92f7f9221d6cea8b40e' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         z.attrs['foo'] = 'bar'
-        eq('05b0663ffe1785f38d3a459dec17e57a18f254af', z.hexdigest())
+        assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
 
     def test_object_arrays_danger(self):
         # skip this one, metadata get reloaded in each process
@@ -206,16 +207,16 @@ class MixinGroupSyncTests(object):
 
         # parallel create group
         n = 100
-        results = pool.map(
+        results = list(pool.map(
             _create_group,
             zip([g] * n, [str(i) for i in range(n)]),
             chunksize=1
-        )
-        results = sorted(results)
+        ))
+        assert n == len(results)
         pool.close()
         pool.terminate()
 
-        eq(n, len(g))
+        assert n == len(g)
 
         pool.terminate()
 
@@ -227,16 +228,16 @@ class MixinGroupSyncTests(object):
 
         # parallel require group
         n = 100
-        results = pool.map(
+        results = list(pool.map(
             _require_group,
             zip([g] * n, [str(i//10) for i in range(n)]),
             chunksize=1
-        )
-        results = sorted(results)
+        ))
+        assert n == len(results)
         pool.close()
         pool.terminate()
 
-        eq(n//10, len(g))
+        assert n//10 == len(g)
 
         pool.terminate()
 
@@ -253,13 +254,14 @@ class TestGroupWithThreadSynchronizer(TestGroup, MixinGroupSyncTests):
                   chunk_store=chunk_store, synchronizer=synchronizer)
         return g
 
+    # noinspection PyMethodMayBeStatic
     def create_pool(self):
         pool = ThreadPool(cpu_count())
         return pool
 
     def test_synchronizer_property(self):
         g = self.create_group()
-        assert_is_instance(g.synchronizer, ThreadSynchronizer)
+        assert isinstance(g.synchronizer, ThreadSynchronizer)
 
 
 class TestGroupWithProcessSynchronizer(TestGroup, MixinGroupSyncTests):
@@ -282,10 +284,11 @@ class TestGroupWithProcessSynchronizer(TestGroup, MixinGroupSyncTests):
                   synchronizer=synchronizer, chunk_store=chunk_store)
         return g
 
+    # noinspection PyMethodMayBeStatic
     def create_pool(self):
         pool = ProcessPool(processes=cpu_count())
         return pool
 
     def test_synchronizer_property(self):
         g = self.create_group()
-        assert_is_instance(g.synchronizer, ProcessSynchronizer)
+        assert isinstance(g.synchronizer, ProcessSynchronizer)

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -3,108 +3,109 @@ from __future__ import absolute_import, print_function, division
 
 
 import numpy as np
-from nose.tools import (eq_ as eq, assert_raises, assert_true, assert_false, assert_is_instance)
+import pytest
 
 
-from zarr.util import (normalize_shape, normalize_chunks, is_total_slice, normalize_resize_args,
-                       human_readable_size, normalize_order, guess_chunks, info_html_report,
-                       info_text_report, normalize_fill_value)
+from zarr.util import (normalize_shape, normalize_chunks, is_total_slice,
+                       normalize_resize_args, human_readable_size, normalize_order,
+                       guess_chunks, info_html_report, info_text_report,
+                       normalize_fill_value)
 
 
 def test_normalize_shape():
-    eq((100,), normalize_shape((100,)))
-    eq((100,), normalize_shape([100]))
-    eq((100,), normalize_shape(100))
-    with assert_raises(TypeError):
+    assert (100,) == normalize_shape((100,))
+    assert (100,) == normalize_shape([100])
+    assert (100,) == normalize_shape(100)
+    with pytest.raises(TypeError):
         normalize_shape(None)
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         normalize_shape('foo')
 
 
 def test_normalize_chunks():
-    eq((10,), normalize_chunks((10,), (100,), 1))
-    eq((10,), normalize_chunks([10], (100,), 1))
-    eq((10,), normalize_chunks(10, (100,), 1))
-    eq((10, 10), normalize_chunks((10, 10), (100, 10), 1))
-    eq((10, 10), normalize_chunks(10, (100, 10), 1))
-    eq((10, 10), normalize_chunks((10, None), (100, 10), 1))
-    eq((30, 20, 10), normalize_chunks(30, (100, 20, 10), 1))
-    eq((30, 20, 10), normalize_chunks((30,), (100, 20, 10), 1))
-    eq((30, 20, 10), normalize_chunks((30, None), (100, 20, 10), 1))
-    eq((30, 20, 10), normalize_chunks((30, None, None), (100, 20, 10), 1))
-    eq((30, 20, 10), normalize_chunks((30, 20, None), (100, 20, 10), 1))
-    eq((30, 20, 10), normalize_chunks((30, 20, 10), (100, 20, 10), 1))
-    with assert_raises(ValueError):
+    assert (10,) == normalize_chunks((10,), (100,), 1)
+    assert (10,) == normalize_chunks([10], (100,), 1)
+    assert (10,) == normalize_chunks(10, (100,), 1)
+    assert (10, 10) == normalize_chunks((10, 10), (100, 10), 1)
+    assert (10, 10) == normalize_chunks(10, (100, 10), 1)
+    assert (10, 10) == normalize_chunks((10, None), (100, 10), 1)
+    assert (30, 20, 10) == normalize_chunks(30, (100, 20, 10), 1)
+    assert (30, 20, 10) == normalize_chunks((30,), (100, 20, 10), 1)
+    assert (30, 20, 10) == normalize_chunks((30, None), (100, 20, 10), 1)
+    assert (30, 20, 10) == normalize_chunks((30, None, None), (100, 20, 10), 1)
+    assert (30, 20, 10) == normalize_chunks((30, 20, None), (100, 20, 10), 1)
+    assert (30, 20, 10) == normalize_chunks((30, 20, 10), (100, 20, 10), 1)
+    with pytest.raises(ValueError):
         normalize_chunks('foo', (100,), 1)
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         normalize_chunks((100, 10), (100,), 1)
 
     # test auto-chunking
     chunks = normalize_chunks(None, (100,), 1)
-    eq((100,), chunks)
+    assert (100,) == chunks
 
 
 def test_is_total_slice():
 
     # 1D
-    assert_true(is_total_slice(Ellipsis, (100,)))
-    assert_true(is_total_slice(slice(None), (100,)))
-    assert_true(is_total_slice(slice(0, 100), (100,)))
-    assert_false(is_total_slice(slice(0, 50), (100,)))
-    assert_false(is_total_slice(slice(0, 100, 2), (100,)))
+    assert is_total_slice(Ellipsis, (100,))
+    assert is_total_slice(slice(None), (100,))
+    assert is_total_slice(slice(0, 100), (100,))
+    assert not is_total_slice(slice(0, 50), (100,))
+    assert not is_total_slice(slice(0, 100, 2), (100,))
 
     # 2D
-    assert_true(is_total_slice(Ellipsis, (100, 100)))
-    assert_true(is_total_slice(slice(None), (100, 100)))
-    assert_true(is_total_slice((slice(None), slice(None)), (100, 100)))
-    assert_true(is_total_slice((slice(0, 100), slice(0, 100)), (100, 100)))
-    assert_false(is_total_slice((slice(0, 100), slice(0, 50)), (100, 100)))
-    assert_false(is_total_slice((slice(0, 50), slice(0, 100)), (100, 100)))
-    assert_false(is_total_slice((slice(0, 50), slice(0, 50)), (100, 100)))
-    assert_false(is_total_slice((slice(0, 100, 2), slice(0, 100)), (100, 100)))
+    assert is_total_slice(Ellipsis, (100, 100))
+    assert is_total_slice(slice(None), (100, 100))
+    assert is_total_slice((slice(None), slice(None)), (100, 100))
+    assert is_total_slice((slice(0, 100), slice(0, 100)), (100, 100))
+    assert not is_total_slice((slice(0, 100), slice(0, 50)), (100, 100))
+    assert not is_total_slice((slice(0, 50), slice(0, 100)), (100, 100))
+    assert not is_total_slice((slice(0, 50), slice(0, 50)), (100, 100))
+    assert not is_total_slice((slice(0, 100, 2), slice(0, 100)), (100, 100))
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         is_total_slice('foo', (100,))
 
 
 def test_normalize_resize_args():
 
     # 1D
-    eq((200,), normalize_resize_args((100,), 200))
-    eq((200,), normalize_resize_args((100,), (200,)))
+    assert (200,) == normalize_resize_args((100,), 200)
+    assert (200,) == normalize_resize_args((100,), (200,))
 
     # 2D
-    eq((200, 100), normalize_resize_args((100, 100), (200, 100)))
-    eq((200, 100), normalize_resize_args((100, 100), (200, None)))
-    eq((200, 100), normalize_resize_args((100, 100), 200, 100))
-    eq((200, 100), normalize_resize_args((100, 100), 200, None))
+    assert (200, 100) == normalize_resize_args((100, 100), (200, 100))
+    assert (200, 100) == normalize_resize_args((100, 100), (200, None))
+    assert (200, 100) == normalize_resize_args((100, 100), 200, 100)
+    assert (200, 100) == normalize_resize_args((100, 100), 200, None)
 
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         normalize_resize_args((100,), (200, 100))
 
 
 def test_human_readable_size():
-    eq('100', human_readable_size(100))
-    eq('1.0K', human_readable_size(2**10))
-    eq('1.0M', human_readable_size(2**20))
-    eq('1.0G', human_readable_size(2**30))
-    eq('1.0T', human_readable_size(2**40))
-    eq('1.0P', human_readable_size(2**50))
+    assert '100' == human_readable_size(100)
+    assert '1.0K' == human_readable_size(2**10)
+    assert '1.0M' == human_readable_size(2**20)
+    assert '1.0G' == human_readable_size(2**30)
+    assert '1.0T' == human_readable_size(2**40)
+    assert '1.0P' == human_readable_size(2**50)
 
 
 def test_normalize_order():
-    eq('F', normalize_order('F'))
-    eq('C', normalize_order('C'))
-    eq('F', normalize_order('f'))
-    eq('C', normalize_order('c'))
-    with assert_raises(ValueError):
+    assert 'F' == normalize_order('F')
+    assert 'C' == normalize_order('C')
+    assert 'F' == normalize_order('f')
+    assert 'C' == normalize_order('c')
+    with pytest.raises(ValueError):
         normalize_order('foo')
 
 
 def test_normalize_fill_value():
-    eq(b'', normalize_fill_value(0, dtype=np.dtype('S1')))
-    eq(b'', normalize_fill_value(0, dtype=np.dtype([('foo', 'i4'), ('bar', 'f8')])))
-    eq('', normalize_fill_value(0, dtype=np.dtype('U1')))
+    assert b'' == normalize_fill_value(0, dtype=np.dtype('S1'))
+    assert b'' == normalize_fill_value(0, dtype=np.dtype([('foo', 'i4'), ('bar', 'f8')]))
+    assert '' == normalize_fill_value(0, dtype=np.dtype('U1'))
 
 
 def test_guess_chunks():
@@ -130,25 +131,25 @@ def test_guess_chunks():
     )
     for shape in shapes:
         chunks = guess_chunks(shape, 1)
-        assert_is_instance(chunks, tuple)
-        eq(len(chunks), len(shape))
+        assert isinstance(chunks, tuple)
+        assert len(chunks) == len(shape)
         # doesn't make any sense to allow chunks to have zero length dimension
         assert all([0 < c <= max(s, 1) for c, s in zip(chunks, shape)])
 
     # ludicrous itemsize
     chunks = guess_chunks((1000000,), 40000000000)
-    assert_is_instance(chunks, tuple)
-    eq((1,), chunks)
+    assert isinstance(chunks, tuple)
+    assert (1,) == chunks
 
 
 def test_info_text_report():
     items = [('foo', 'bar'), ('baz', 'qux')]
     expect = "foo : bar\nbaz : qux\n"
-    eq(expect, info_text_report(items))
+    assert expect == info_text_report(items)
 
 
 def test_info_html_report():
     items = [('foo', 'bar'), ('baz', 'qux')]
     actual = info_html_report(items)
-    eq('<table', actual[:6])
-    eq('</table>', actual[-8:])
+    assert '<table' == actual[:6]
+    assert '</table>' == actual[-8:]


### PR DESCRIPTION
This PR completes the migration to pytest and removes all use of nose. Resolves #189.

(N.B., nose is still retained in requirements_dev.txt because it is needed by numcodecs.)